### PR TITLE
BOT adding alignments

### DIFF
--- a/BRICKAlignment.ttl
+++ b/BRICKAlignment.ttl
@@ -1,0 +1,64 @@
+@prefix : <https://w3id.org/bot/BRICKAlignment#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .  
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix bot: <https://w3id.org/bot#> .
+@prefix brick: <https://brickschema.org/schema/1.0.2/Brick#> .
+@base <https://w3id.org/bot/BRICKAlignment> .
+
+<https://w3id.org/bot/BRICKAlignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "BRICK to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the BRICK ontology."""@en ;
+	dcterms:issued "2017-09-12"^^xsd:date ;
+	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	owl:imports 	<https://w3id.org/bot> ,
+					<https://brickschema.org/schema/1.0.2/Brick#> .
+
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:issued a owl:AnnotationProperty .
+dcterms:modified a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+dcterms:contributor a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+foaf:Person a owl:Class .
+foaf:name a owl:DatatypeProperty .
+
+											   
+#################################################################
+#    Object Properties
+#################################################################
+
+brick:contains rdfs:subPropertyOf bot:containsElement .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+bot:Space rdfs:subClassOf brick:Location .
+brick:Basement rdfs:subClassOf bot:Space .
+brick:Outside rdfs:subClassOf bot:Space .
+brick:Room rdfs:subClassOf bot:Space .
+brick:Space rdfs:subClassOf bot:Space .
+brick:Wing rdfs:subClassOf bot:Space .
+brick:Zone rdfs:subClassOf bot:Space .
+
+bot:Building owl:equivalentClass brick:Building .
+bot:Storey owl:equivalentClass brick:Floor .
+
+brick:Equipment rdfs:subClassOf bot:Element .
+
+brick:Point rdfs:subClassOf bot:Element .
+
+

--- a/BRICKAlignment.ttl
+++ b/BRICKAlignment.ttl
@@ -46,7 +46,7 @@ brick:contains rdfs:subPropertyOf bot:containsElement .
 #    Classes
 #################################################################
 
-bot:Space rdfs:subClassOf brick:Location .
+bot:Zone rdfs:subClassOf brick:Location .
 brick:Basement rdfs:subClassOf bot:Space .
 brick:Outside rdfs:subClassOf bot:Space .
 brick:Room rdfs:subClassOf bot:Space .
@@ -54,11 +54,12 @@ brick:Space rdfs:subClassOf bot:Space .
 brick:Wing rdfs:subClassOf bot:Space .
 brick:Zone rdfs:subClassOf bot:Space .
 
-bot:Building owl:equivalentClass brick:Building .
-bot:Storey owl:equivalentClass brick:Floor .
+brick:Building rdfs:subClassOf bot:Building .
+brick:Floor rdfs:subClassOf bot:Storey .
 
 brick:Equipment rdfs:subClassOf bot:Element .
 
 brick:Point rdfs:subClassOf bot:Element .
 
+brick:contains rdfs:subPropertyOf bot:containsElement  .
 

--- a/DERIROOMAlignment.ttl
+++ b/DERIROOMAlignment.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://w3id.org/bot/IFC4_ADD2Alignment#> .
+@prefix : <https://w3id.org/bot/DERIROOMSAlignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -8,19 +8,19 @@
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix bot: <https://w3id.org/bot#> .
-@prefix ifc: <http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#> .
-@base <https://w3id.org/bot/IFC4_ADD2Alignment> .
+@prefix rooms: <http://vocab.deri.ie/rooms#> .
+@base <https://w3id.org/bot/DERIROOMSAlignment> .
 
-<https://w3id.org/bot/IFC4_ADD2Alignment> rdf:type owl:Ontology , voaf:Vocabulary ;
-	dcterms:title "ifcOWL4_Add2 to BOT alignment."@en ;
-	dcterms:description """This ontology defines proposed alignments with the ifcOWL4_Add2 ontology."""@en ;
+<https://w3id.org/bot/DERIROOMSAlignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "DERIROOMS to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the DERI Rooms ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
 	dcterms:modified "2017-09-12"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
 	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,
-					<http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2> .
+					<http://vocab.deri.ie/rooms#> .
 
 dcterms:title a owl:AnnotationProperty .
 dcterms:description a owl:AnnotationProperty .
@@ -35,22 +35,14 @@ foaf:Person a owl:Class .
 foaf:name a owl:DatatypeProperty .
 
 #################################################################
-#    Classes
+#    Alignments
 #################################################################
 
-ifc:IfcSite rdfs:subClassOf bot:Site .
-ifc:IfcBuilding rdfs:subClassOf bot:Building .
-ifc:IfcBuildingStorey rdfs:subClassOf bot:Storey .
-ifc:IfcSpace rdfs:subClassOf bot:Space .
-ifc:IfcElement rdfs:subClassOf bot:Element .
+rooms:Site rdfs:subClassOf bot:Site .
+rooms:Building rdfs:subClassOf bot:Building .
+rooms:Floor rdfs:subClassOf bot:Storey .
+rooms:FloorSection rdfs:subClassOf bot:Storey .
+rooms:Desk rdfs:subClassOf bot:Element .
+rooms:Room rdfs:subClassOf bot:Space .
 
-
-
-
-
-
-
-
-
-
-
+rooms:contains rdfs:subPropertyOf bot:containsZone .

--- a/DOGONTAlignment.ttl
+++ b/DOGONTAlignment.ttl
@@ -1,0 +1,53 @@
+@prefix : <https://w3id.org/bot/DOGONTAlignment#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .  
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix bot: <https://w3id.org/bot#> .
+@prefix dogont: <http://elite.polito.it/ontologies/dogont.owl#> .
+@base <https://w3id.org/bot/DOGONTAlignment> .
+
+<https://w3id.org/bot/DOGONTAlignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "DogOnt to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the DogOnt ontology."""@en ;
+	dcterms:issued "2017-09-12"^^xsd:date ;
+	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	owl:imports 	<https://w3id.org/bot> ,
+					<http://elite.polito.it/ontologies/dogont.owl> .
+
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:issued a owl:AnnotationProperty .
+dcterms:modified a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+dcterms:contributor a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+foaf:Person a owl:Class .
+foaf:name a owl:DatatypeProperty .
+
+#################################################################
+#    Classes
+#################################################################
+
+bot:Building owl:equivalentClass dogont:Building .
+dogont:Flat rdfs:subClassOf bot:Building .
+bot:Storey owl:equivalentClass dogont:Storey .
+
+bot:Space rdfs:subClassOf dogont:BuildingEnvironment .
+dogont:Room rdfs:subClassOf bot:Space .
+dogont:Garage rdfs:subClassOf bot:Space .
+dogont:Garden rdfs:subClassOf bot:Space .
+
+dogont:Controllable 	rdfs:subClassOf bot:Element .
+dogont:Device 			rdfs:subClassOf bot:Element .
+dogont:UnControllable	rdfs:subClassOf bot:Element .
+dogont:TechnicalSystem	rdfs:subClassOf bot:Element .

--- a/DOGONTAlignment.ttl
+++ b/DOGONTAlignment.ttl
@@ -38,16 +38,19 @@ foaf:name a owl:DatatypeProperty .
 #    Classes
 #################################################################
 
-bot:Building owl:equivalentClass dogont:Building .
+dogont:Building rdfs:subClassOf bot:Building .
 dogont:Flat rdfs:subClassOf bot:Building .
-bot:Storey owl:equivalentClass dogont:Storey .
+dogont:Storey rdfs:subClassOf bot:Storey .
 
-bot:Space rdfs:subClassOf dogont:BuildingEnvironment .
+bot:Zone rdfs:subClassOf dogont:Environment .
+dogont:BuildingEnvironment rdfs:subClassOf bot:Zone.
+
 dogont:Room rdfs:subClassOf bot:Space .
-dogont:Garage rdfs:subClassOf bot:Space .
-dogont:Garden rdfs:subClassOf bot:Space .
 
 dogont:Controllable 	rdfs:subClassOf bot:Element .
 dogont:Device 			rdfs:subClassOf bot:Element .
 dogont:UnControllable	rdfs:subClassOf bot:Element .
 dogont:TechnicalSystem	rdfs:subClassOf bot:Element .
+
+dogont:hasWallOpening rdfs:subPropertyOf bot:hosts .
+

--- a/IFCOWL4_ADD2Alignment.ttl
+++ b/IFCOWL4_ADD2Alignment.ttl
@@ -1,0 +1,56 @@
+@prefix : <https://w3id.org/bot/IFC4_ADD2Alignment#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .  
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix bot: <https://w3id.org/bot#> .
+@prefix ifc: <http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#> .
+@base <https://w3id.org/bot/IFC4_ADD2Alignment> .
+
+<https://w3id.org/bot/IFC4_ADD2Alignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "ifcOWL4_Add2 to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the ifcOWL4_Add2 ontology."""@en ;
+	dcterms:issued "2017-09-12"^^xsd:date ;
+	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	owl:imports 	<https://w3id.org/bot> ,
+					<http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2> .
+
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:issued a owl:AnnotationProperty .
+dcterms:modified a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+dcterms:contributor a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+foaf:Person a owl:Class .
+foaf:name a owl:DatatypeProperty .
+
+#################################################################
+#    Classes
+#################################################################
+
+bot:Site owl:equivalentClass ifc:IfcSite .
+bot:Building owl:equivalentClass ifc:IfcBuilding .
+bot:Storey owl:equivalentClass ifc:IfcBuildingStorey .
+bot:Space owl:equivalentClass ifc:IfcSpace .
+bot:Element owl:equivalentClass ifc:IfcElement .
+
+
+
+
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ DogOnt [link](http://elite.polito.it/ontologies/dogont.owl#)
 
 ifcOWL [link](http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#)
 
+rooms [link](http://vocab.deri.ie/rooms.html)
+
 ## Example of using BOT
 
 Example of using BOT in [Turtle syntax](https://www.w3.org/TeamSubmission/turtle/).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ So far an alignment for the following ontologied has been provided:
 
 SAREF4Bldg [link](https://w3id.org/def/saref4bldg#)
 
-Intended alignments include (non-exhaustively)
-
 ThinkHome [link](https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl)
 
 DogOnt [link](http://elite.polito.it/ontologies/dogont.owl#)

--- a/SAREF4BLDGAlignment.ttl
+++ b/SAREF4BLDGAlignment.ttl
@@ -45,8 +45,8 @@ foaf:name a owl:DatatypeProperty .
   dcterms:description """This ontology defines proposed alignments of SAREF4BLDG with the BOT ontology."""@en ;
   dcterms:issued "2017-07-13"^^xsd:date ;
   dce:modified "2017-08-31"^^xsd:date ;
-  dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
   dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+  dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
   dcterms:contributor [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
   dcterms:contributor [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
   dcterms:contributor <http://www.maxime-lefrancois.info/me#> ;
@@ -60,7 +60,7 @@ foaf:name a owl:DatatypeProperty .
 #################################
       
 bot:Building		owl:equivalentClass		saref4bldg:Building .
-bot:Element			rdfs:subClassOf			saref4bldg:PhysicalObject .
+bot:Element			owl:equivalentClass		saref4bldg:PhysicalObject .
 bot:Space			owl:equivalentClass 	saref4bldg:BuildingSpace .
 bot:hasSpace 		rdfs:subPropertyOf  	saref4bldg:hasSpace .
 bot:containsElement	owl:equivalentProperty 	saref4bldg:contains .

--- a/SAREF4BLDGAlignment.ttl
+++ b/SAREF4BLDGAlignment.ttl
@@ -51,16 +51,18 @@ foaf:name a owl:DatatypeProperty .
   dcterms:contributor [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
   dcterms:contributor <http://www.maxime-lefrancois.info/me#> ;
   dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
-  owl:versionInfo "v0.1.0" ;
+  owl:versionInfo "v0.2.0" ;
   owl:imports <https://w3id.org/bot> ;
   owl:imports <https://w3id.org/def/saref4bldg> .
    
 #################################
 # ALIGNMENTS
 #################################
-      
-bot:Building		owl:equivalentClass		saref4bldg:Building .
-bot:Element			owl:equivalentClass		saref4bldg:PhysicalObject .
-bot:Space			owl:equivalentClass 	saref4bldg:BuildingSpace .
-bot:hasSpace 		rdfs:subPropertyOf  	saref4bldg:hasSpace .
-bot:containsElement	owl:equivalentProperty 	saref4bldg:contains .
+
+saref4bldg:Building         rdfs:subClassOf bot:Building .      
+saref4bldg:PhysicalObject   rdfs:subClassOf bot:Element .
+saref4bldg:BuildingSpace    rdfs:subClassOf bot:Space .
+
+saref4bldg:hasSpace         rdfs:subPropertyOf bot:hasSpace .
+saref4bldg:contains         rdfs:subPropertyOf bot:containsElement .
+

--- a/THINKHOMEAlignment.ttl
+++ b/THINKHOMEAlignment.ttl
@@ -38,27 +38,30 @@ foaf:name a owl:DatatypeProperty .
 #    Classes
 #################################################################
 
-bot:Site owl:equivalentClass th:Campus .
-bot:Building owl:equivalentClass th:Building .
-bot:Storey owl:equivalentClass th:BuildingStorey .
+th:Campus rdfs:subClassOf bot:Site .
+th:Building rdfs:subClassOf bot:Building .
+th:BuildingStorey rdfs:subClassOf bot:Storey .
 
 th:Zone rdfs:subClassOf bot:Space .
 th:Space rdfs:subClassOf bot:Space .
+
+th:SpaceBoundary rdfs:subClassOf bot:Interface .
+th:Surface rdfs:subClassOf bot:Interface .
 
 th:Equipment rdfs:subClassOf bot:Element .
 th:Construction rdfs:subClassOf bot:Element .
 th:Layer rdfs:subClassOf bot:Element .
 th:Material rdfs:subClassOf bot:Element .
 th:Opening rdfs:subClassOf bot:Element .
-th:Surface rdfs:subClassOf bot:Element .
 
+th:containsBuilding rdfs:subPropertyOf bot:containsZone .
+th:containsBuildingStorey rdfs:subPropertyOf bot:containsZone .
+th:containsLocation rdfs:subPropertyOf bot:containsZone .
 
+th:containsOpening rdfs:subPropertyOf bot:hosts .
 
+th:containsSpace rdfs:subPropertyOf bot:hasSpace .
 
+th:hasDefinedAdjacentSpace rdfs:subPropertyOf bot:adjacentZone .
 
-
-
-
-
-
-
+th:isDefinedAdjacentSurfaceOf rdfs:subPropertyOf bot:interfaceOf .

--- a/THINKHOMEAlignment.ttl
+++ b/THINKHOMEAlignment.ttl
@@ -1,0 +1,64 @@
+@prefix : <https://w3id.org/bot/THINKHOMEAlignment#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .  
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix bot: <https://w3id.org/bot#> .
+@prefix th: <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#> .
+@base <https://w3id.org/bot/THINKHOMEAlignment> .
+
+<https://w3id.org/bot/THINKHOMEAlignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "ThinkHome to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the ThinkHome ontologies."""@en ;
+	dcterms:issued "2017-09-12"^^xsd:date ;
+	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	owl:imports 	<https://w3id.org/bot> ,
+					<https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl> .
+
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:issued a owl:AnnotationProperty .
+dcterms:modified a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+dcterms:contributor a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+foaf:Person a owl:Class .
+foaf:name a owl:DatatypeProperty .
+
+#################################################################
+#    Classes
+#################################################################
+
+bot:Site owl:equivalentClass th:Campus .
+bot:Building owl:equivalentClass th:Building .
+bot:Storey owl:equivalentClass th:BuildingStorey .
+
+th:Zone rdfs:subClassOf bot:Space .
+th:Space rdfs:subClassOf bot:Space .
+
+th:Equipment rdfs:subClassOf bot:Element .
+th:Construction rdfs:subClassOf bot:Element .
+th:Layer rdfs:subClassOf bot:Element .
+th:Material rdfs:subClassOf bot:Element .
+th:Opening rdfs:subClassOf bot:Element .
+th:Surface rdfs:subClassOf bot:Element .
+
+
+
+
+
+
+
+
+
+
+

--- a/bot.ttl
+++ b/bot.ttl
@@ -13,13 +13,10 @@
 @prefix dcterms:	<http://purl.org/dc/terms/> .
 @prefix vann:   	<http://purl.org/vocab/vann/> .
 @prefix voaf:   	<http://purl.org/vocommons/voaf#> .
-@prefix vs:     	<http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix foaf:   	<http://xmlns.com/foaf/0.1/> .
 @prefix dce:    	<http://purl.org/dc/elements/1.1/> .
-@prefix dbo:    	<http://dbpedia.org/ontology/> .
-
 @prefix bot: <https://w3id.org/bot#> .
-@base <https://w3id.org/bot#> .
+@base <https://w3id.org/bot> .
 
 voaf:Vocabulary a owl:Class .
 dcterms:title a owl:AnnotationProperty .
@@ -31,17 +28,16 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-vs:term_status a owl:AnnotationProperty .
 foaf:Person a owl:Class .
 foaf:name a owl:DatatypeProperty .
 
 #################################
 # METADATA
 #################################
-<https://w3id.org/bot#> rdf:type voaf:Vocabulary , 
+<https://w3id.org/bot> rdf:type voaf:Vocabulary , 
                                  owl:Ontology ;
-    dce:modified "July 11th 2017"^^xsd:string ;
-    owl:versionInfo "July 11th 2017"^^xsd:string ;
+    dce:modified "2017-07-11"^^xsd:date ;
+    owl:versionInfo "2017-07-11"^^xsd:date ;
     dcterms:issued "2017-07-11"^^xsd:date ;
     #owl:versionIRI <https://w3id.org/bot/bot-0.1.1> ;
     owl:versionInfo "v0.1.1" ;
@@ -70,7 +66,7 @@ bot:Site a owl:Class ;
         rdfs:label      "Site"@en ,
                         "Grund"@da ,
                         "Site"@nl ,
-						"Grundstück"@de .
+						"Grundstück"@de ;
         rdfs:comment    "Area containing one or more buildings."@en ,
                         "Område som indeholder en eller flere bygninger."@da ,
 						"Omgeving die één of meerdere gebouwen bevat."@nl ,
@@ -96,7 +92,7 @@ bot:Storey a owl:Class ;
         rdfs:comment    "A level part of a building"@en ,
 						"Die Gesamtheit aller Räume in einem Gebäude, die auf einer Zugangsebene liegen und horizontal verbunden sind"@de ,
                         "Et plan i en bygning"@da ,
-						"Een horizontaal gedeelte van een gebouw"@nl.
+						"Een horizontaal gedeelte van een gebouw"@nl .
 						
 bot:Element a owl:Class ;
         rdfs:label      "Building element"@en ,


### PR DESCRIPTION
Dear all!

please find in the following pull request a proposal to align

BRICK
DogOnt
ThinkHome
ifcOWL4_Add2

Ontologies to BOT via seperate alignment files.

I propose a merge after after some reviewing time. Also I would like to invite the respective domain ontology developers to add to the discussion in this pull request and possible deploy changes.

This should solve #3 and #4 