### PR TITLE
updated error typo regarding datatype of string

### DIFF
--- a/bot.ttl
+++ b/bot.ttl
@@ -39,7 +39,7 @@ foaf:name a owl:DatatypeProperty .
 <https://w3id.org/bot#> rdf:type owl:Ontology , voaf:Vocabulary ;
     dcterms:modified    "2017-10-27"^^xsd:date ;
     dcterms:issued    "2017-10-27"^^xsd:date ;
-    owl:versionInfo    "0.2.0"^^xsd:date ;
+    owl:versionInfo    "0.2.0" ;
     owl:versionIRI <https://w3id.org/bot/0.2.0> ;
     owl:priorVersion <https://w3id.org/bot/0.1.1> ;
   rdfs:seeAlso <https://doi.org/10.24928/JC3-2017/0153> , <https://www.researchgate.net/publication/320631574_Recent_changes_in_the_Building_Topology_Ontology> ;


### PR DESCRIPTION
On line 42 of the BOT ontology, the value contained a wrong datatype of xsd:date while it is a string. This makes that my Stardog triplestore refuses to read the bot.ttl 

fixes #31