### PR TITLE
added disjoint property axioms

### DIFF
--- a/bot.ttl
+++ b/bot.ttl
@@ -201,7 +201,7 @@ bot:adjacentZone a owl:ObjectProperty , owl:SymmetricProperty ;
     "angränsande zon"@se ,
     "zone adjacente"@fr ;
   rdfs:comment
-    "Relationship between two zones sharing a common interface."@en ,
+    "Relationship between two zones sharing a common interface. A zone cannot have a bot:adjacentZone relation with a bot:Zone it contains."@en ,
     "Relatie tussen twee zones die een interface delen"@nl ,
     "Relation mellem to zoner, der deler en fælles grænseflade."@da ,
     "Relation mellan två zoner som delar ett gemensamt gränssnitt."@se ,
@@ -230,7 +230,7 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
     "innehåller zon"@se ,
     "contient zone"@fr ;
   rdfs:comment
-    "Relationship to the subzones of a major zone. A space zone could for instance be contained in a storey zone which is further contained in a building zone. bot:containsZone is a transitive property meaning that in the previous example the space zone would also be contained in the building zone."@en ,
+    "Relationship to the subzones of a major zone. A space zone could for instance be contained in a storey zone which is further contained in a building zone. bot:containsZone is a transitive property meaning that in the previous example the space zone would also be contained in the building zone. A zone cannot have a bot:containsZone relation with an adjacent bot:Zone"@en ,
     "Relation til underzoner i en større zone. En rum-zone kan for eksempel være indeholdt i en etage-zone som ydermere er indeholdt i en bygnings-zone. bot:containsZone er en transitiv egenskab, hvilket betyder at rum-zonen i det forrige eksempel også er indeholdt i bygnings-zonen."@da ,
     "Relation till delzoner i en huvudzon. En rumszon kan till exempel inrymmas i en våningszon som i sin tur inryms i en byggnadszon. bot:containsZone är en transitiv relation vilket i exemplet betyder att rumszonen också inryms i byggnadszonen."@se ,
     "Relatie tussen subzones van een hoofd zone. Een ruimtezone kan bijvoorbeeld worden bevat door een verdiepingszone, die wederom bevat wordt door een gebouwzone. bot:containsZone is een transitieve eigenschap, wat betekent dat in het vorige voorbeeld de ruimtezone ook bevat wordt door de gebouwzone."@nl ,
@@ -389,7 +389,7 @@ bot:hasElement a owl:ObjectProperty ;
       "angränsande element"@se ,
       "élément adjacent"@fr ;
     rdfs:comment
-      "Relation between a zone and its adjacent building elements, bounding the zone."@en ,
+      "Relation between a zone and its adjacent building elements, bounding the zone. A zone cannot have a bot:containsElement relation with an adjacent bot:Element."@en ,
       "Relación entre una zona y sus elementos arquitectónicos adyacentes, que limitan el espacio físico."@es ,
       #"Beziehung eines Raumes zu Bauteilen die in begrenzen"@de ,
       "Relatie tussen een zone en zijn aangrenzende gebouwelementen, begrensd door fysieke ruimte."@nl ,
@@ -409,7 +409,7 @@ bot:hasElement a owl:ObjectProperty ;
       "innehåller byggdel"@se ,
       "contient élément"@fr ;        
     rdfs:comment
-      "Relation to a building element contained in a zone."@en ,
+      "Relation to a building element contained in a zone. A zone cannot have a bot:adjacentElement relation with a bot:Element it contains."@en ,
       "Relación a un elemento arquitectónico contenido en una zona."@es ,
       #"Beziehung eines Raums zu einem Bauteil"@de ,
       "Relatie tussen zone en een gebouwelement in die zone"@nl ,
@@ -472,8 +472,13 @@ bot:interfaceOf a owl:ObjectProperty ;
 [] a owl:AllDisjointClasses ;
         owl:members
               ( 
-    bot:Site
-    bot:Element
+				bot:Site
+				bot:Element
                 bot:Space
                 bot:Storey
                 bot:Building ) .
+
+# Disjunctive properties
+bot:containsElement owl:propertyDisjointWith bot:adjacentElement .
+
+bot:containsZone owl:propertyDisjointWith bot:adjacentZone .


### PR DESCRIPTION
As discussed in #24 a disjoint property axiom is added for `bot:containsElement` and `bot:adjacentElement`. A similar axiom was added for `bot:containsZone` and `bot:adjacentZone`. All four the definitions of the properties are updated: either bot:containsElement/Zone or bot:adjacentElement/Zone has to be used, but not both.

The main reason behind this restriction, is that a `bot:containsZone` / `bot:containsElement` relation means that the **complete** `bot:Zone` / `bot:Element` has to be contained in the other `bot:Zone`, instead of only partially.