### PR TITLE
Alignment revision

### DIFF
--- a/BRICKAlignment.ttl
+++ b/BRICKAlignment.ttl
@@ -1,3 +1,11 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
 @prefix : <https://w3id.org/bot/BRICKAlignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -15,9 +23,13 @@
 	dcterms:title "BRICK to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the BRICK ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
-	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:modified "2019-03-01"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v1.0.0" ;
+    owl:versionIRI <https://w3id.org/bot/BRICKAlignment/1.0.0> ;
+    owl:priorVersion <https://w3id.org/bot/BRICKAlignment/0.1.0> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
 	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<https://brickschema.org/schema/1.0.2/Brick#> .
@@ -41,12 +53,21 @@ foaf:name a owl:DatatypeProperty .
 
 brick:contains rdfs:subPropertyOf bot:containsElement .
 
+brick:hasPart rdfs:subPropertyOf bot:containsZone .
+brick:hasPart rdfs:subPropertyOf bot:containsElement .
+brick:hasPart rdfs:subPropertyOf bot:hasSubElement .
+brick:hasPoint rdfs:subPropertyOf bot:containsZone .
+brick:hasPoint rdfs:subPropertyOf bot:containsElement .
 
 #################################################################
 #    Classes
 #################################################################
 
-bot:Zone rdfs:subClassOf brick:Location .
+brick:Location rdfs:subClassOf bot:Zone .
+
+brick:Building rdfs:subClassOf bot:Building .
+brick:Floor rdfs:subClassOf bot:Storey .
+
 brick:Basement rdfs:subClassOf bot:Space .
 brick:Outside rdfs:subClassOf bot:Space .
 brick:Room rdfs:subClassOf bot:Space .
@@ -54,12 +75,5 @@ brick:Space rdfs:subClassOf bot:Space .
 brick:Wing rdfs:subClassOf bot:Space .
 brick:Zone rdfs:subClassOf bot:Space .
 
-brick:Building rdfs:subClassOf bot:Building .
-brick:Floor rdfs:subClassOf bot:Storey .
-
 brick:Equipment rdfs:subClassOf bot:Element .
-
 brick:Point rdfs:subClassOf bot:Element .
-
-brick:contains rdfs:subPropertyOf bot:containsElement  .
-

--- a/DERIROOMAlignment.ttl
+++ b/DERIROOMAlignment.ttl
@@ -1,3 +1,11 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
 @prefix : <https://w3id.org/bot/DERIROOMSAlignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -15,8 +23,12 @@
 	dcterms:title "DERIROOMS to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the DERI Rooms ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
-	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:modified "2019-03-01"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v1.0.0" ;
+    owl:versionIRI <https://w3id.org/bot/DERIROOMSAlignment/1.0.0> ;
+    owl:priorVersion <https://w3id.org/bot/DERIROOMSAlignment/0.1.0> ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
 	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,

--- a/DOGONTAlignment.ttl
+++ b/DOGONTAlignment.ttl
@@ -1,3 +1,11 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
 @prefix : <https://w3id.org/bot/DOGONTAlignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -15,9 +23,13 @@
 	dcterms:title "DogOnt to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the DogOnt ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
-	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:modified "2019-03-02"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v1.0.0" ;
+    owl:versionIRI <https://w3id.org/bot/DOGONTAlignment/1.0.0> ;
+    owl:priorVersion <https://w3id.org/bot/DOGONTAlignment/0.1.0> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
 	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://elite.polito.it/ontologies/dogont.owl> .
@@ -35,22 +47,37 @@ foaf:Person a owl:Class .
 foaf:name a owl:DatatypeProperty .
 
 #################################################################
+#    Object properties
+#################################################################
+
+dogont:contains rdfs:subPropertyOf bot:containsElement .
+dogont:belongsTo rdfs:subPropertyOf [ owl:inverseOf bot:hasSubElement ] .
+dogont:floorOf rdfs:subPropertyOf bot:interfaceOf .
+dogont:ceilingOf rdfs:subPropertyOf bot:interfaceOf .
+dogont:hasWall rdfs:subPropertyOf bot:adjacentElement .
+dogont:hasWallOpening rdfs:subPropertyOf bot:hasSubElement .
+
+#################################################################
 #    Classes
 #################################################################
 
 dogont:Building rdfs:subClassOf bot:Building .
-dogont:Flat rdfs:subClassOf bot:Building .
 dogont:Storey rdfs:subClassOf bot:Storey .
+dogont:Room rdfs:subClassOf bot:Space .
 
 bot:Zone rdfs:subClassOf dogont:Environment .
-dogont:BuildingEnvironment rdfs:subClassOf bot:Zone.
-
+dogont:BuildingEnvironment rdfs:subClassOf bot:Zone .
 dogont:Room rdfs:subClassOf bot:Space .
+dogont:Balcony	rdfs:subClassOf bot:Zone .
+dogont:Terrace	rdfs:subClassOf bot:Zone .
 
 dogont:Controllable 	rdfs:subClassOf bot:Element .
 dogont:Device 			rdfs:subClassOf bot:Element .
-dogont:UnControllable	rdfs:subClassOf bot:Element .
 dogont:TechnicalSystem	rdfs:subClassOf bot:Element .
 
-dogont:hasWallOpening rdfs:subPropertyOf bot:hosts .
+dogont:Vertical	    rdfs:subClassOf bot:Element .
+dogont:Furniture    rdfs:subClassOf bot:Element .
+
+dogont:Ceiling	rdfs:subClassOf bot:Interface .
+dogont:Floor	rdfs:subClassOf bot:Interface .
 

--- a/DULAlignment.ttl
+++ b/DULAlignment.ttl
@@ -51,8 +51,7 @@ foaf:name a owl:DatatypeProperty .
 #    Classes
 #################################################################
 
-bot:Site rdfs:subClassOf dul:PhysicalObject .
-bot:Interface rdfs:subClassOf dul:PhysicalObject .#really?
+bot:Interface rdfs:subClassOf dul:PhysicalObject .
 
 bot:Site rdfs:subClassOf dul:PhysicalPlace .
 

--- a/DULAlignment.ttl
+++ b/DULAlignment.ttl
@@ -1,0 +1,75 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
+@prefix : <https://w3id.org/bot/DULAlignment#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .  
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix bot: <https://w3id.org/bot#> .
+@prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
+@base <https://w3id.org/bot/DULAlignment> .
+
+<https://w3id.org/bot/DUL2Alignment> rdf:type owl:Ontology , voaf:Vocabulary ;
+	dcterms:title "DUL to BOT alignment."@en ;
+	dcterms:description """This ontology defines proposed alignments with the DUL ontology."""@en ;
+	dcterms:issued "2019-05-08"^^xsd:date ;
+	dcterms:modified "2019-05-08"^^xsd:date ;
+	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v0.1.0" ;
+    owl:versionIRI <https://w3id.org/bot/DULAlignment/0.1.0> ;
+	dcterms:creator <http://maxime-lefrancois.info/me#> ;
+	dcterms:contributor <https://www.researchgate.net/profile/Georg_Schneider3> ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
+	dcterms:contributor [ a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	dcterms:creator [ a foaf:Person ; foaf:name "Maxime Lefrançois" ] ;
+	owl:imports 	<https://w3id.org/bot> ,
+					<http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> .
+
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:issued a owl:AnnotationProperty .
+dcterms:modified a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+dcterms:contributor a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+foaf:Person a owl:Class .
+foaf:name a owl:DatatypeProperty .
+
+#################################################################
+#    Classes
+#################################################################
+
+bot:Site rdfs:subClassOf dul:PhysicalObject .
+bot:Interface rdfs:subClassOf dul:PhysicalObject .#really?
+
+bot:Site rdfs:subClassOf dul:PhysicalPlace .
+
+bot:Building rdfs:subClassOf dul:DesignedArtifact .
+bot:Storey rdfs:subClassOf dul:DesignedArtifact .
+bot:Space rdfs:subClassOf dul:DesignedArtifact .
+bot:Element rdfs:subClassOf dul:DesignedArtifact .
+
+bot:has3DModel rdfs:subPropertyOf dul:hasRegion .
+bot:has3DModel rdfs:range dul:SpaceRegion .
+
+bot:containsZone rdfs:subPropertyOf dul:hasPart .
+bot:containsElement rdfs:subPropertyOf dul:hasPart .
+
+bot:adjacentZone rdfs:subPropertyOf dul:hasCommonBoundary .
+bot:adjacentElement rdfs:subPropertyOf dul:hasCommonBoundary .
+
+bot:intersectsZone rdfs:subPropertyOf dul:overlaps .
+bot:intersectingElement rdfs:subPropertyOf dul:overlaps .
+bot:interfaceOf rdfs:subPropertyOf dul:overlaps .

--- a/DULAlignment.ttl
+++ b/DULAlignment.ttl
@@ -51,6 +51,7 @@ foaf:name a owl:DatatypeProperty .
 #    Classes
 #################################################################
 
+bot:Zone rdfs:subClassOf dul:PhysicalObject .
 bot:Interface rdfs:subClassOf dul:PhysicalObject .
 
 bot:Site rdfs:subClassOf dul:PhysicalPlace .

--- a/IFCOWL4_ADD2Alignment.ttl
+++ b/IFCOWL4_ADD2Alignment.ttl
@@ -1,3 +1,11 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
 @prefix : <https://w3id.org/bot/IFC4_ADD2Alignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -15,10 +23,14 @@
 	dcterms:title "ifcOWL4_Add2 to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the ifcOWL4_Add2 ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
-	dcterms:modified "2017-09-12"^^xsd:date ;
+	dcterms:modified "2019-03-02"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v1.0.0" ;
+    owl:versionIRI <https://w3id.org/bot/IFC4_ADD2Alignment/1.0.0> ;
+    owl:priorVersion <https://w3id.org/bot/IFC4_ADD2Alignment/0.1.0> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
-	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
+	dcterms:creator [ a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2> .
 
@@ -43,14 +55,3 @@ ifc:IfcBuilding rdfs:subClassOf bot:Building .
 ifc:IfcBuildingStorey rdfs:subClassOf bot:Storey .
 ifc:IfcSpace rdfs:subClassOf bot:Space .
 ifc:IfcElement rdfs:subClassOf bot:Element .
-
-
-
-
-
-
-
-
-
-
-

--- a/ResultsAlignmentMaker/BOT2DERIRoomAlignment.rdf
+++ b/ResultsAlignmentMaker/BOT2DERIRoomAlignment.rdf
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF xmlns='http://knowledgeweb.semanticweb.org/heterogeneity/alignment'
+	 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+	 xmlns:xsd='http://www.w3.org/2001/XMLSchema#' 
+	 alignmentSource='AgreementMakerLight'>
+
+<Alignment>
+	<xml>yes</xml>
+	<level>0</level>
+	<type>11</type>
+	<onto1>https://w3id.org/bot#</onto1>
+	<onto2>http://vocab.deri.ie/rooms</onto2>
+	<uri1>https://w3id.org/bot#</uri1>
+	<uri2>http://vocab.deri.ie/rooms</uri2>
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Site"/>
+			<entity2 rdf:resource="http://vocab.deri.ie/rooms#Site"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.99</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Building"/>
+			<entity2 rdf:resource="http://vocab.deri.ie/rooms#Building"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.9801</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+</Alignment>
+</rdf:RDF>

--- a/ResultsAlignmentMaker/BOT2DogOntAlignment.rdf
+++ b/ResultsAlignmentMaker/BOT2DogOntAlignment.rdf
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF xmlns='http://knowledgeweb.semanticweb.org/heterogeneity/alignment'
+	 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+	 xmlns:xsd='http://www.w3.org/2001/XMLSchema#' 
+	 alignmentSource='AgreementMakerLight'>
+
+<Alignment>
+	<xml>yes</xml>
+	<level>0</level>
+	<type>11</type>
+	<onto1>https://w3id.org/bot#</onto1>
+	<onto2>http://elite.polito.it/ontologies/dogont.owl</onto2>
+	<uri1>https://w3id.org/bot#</uri1>
+	<uri2>http://elite.polito.it/ontologies/dogont.owl</uri2>
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Storey"/>
+			<entity2 rdf:resource="http://elite.polito.it/ontologies/dogont.owl#Storey"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.99</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Building"/>
+			<entity2 rdf:resource="http://elite.polito.it/ontologies/dogont.owl#Building"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.9807</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+</Alignment>
+</rdf:RDF>

--- a/ResultsAlignmentMaker/BOT2IfcOWLAlignment.rdf
+++ b/ResultsAlignmentMaker/BOT2IfcOWLAlignment.rdf
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF xmlns='http://knowledgeweb.semanticweb.org/heterogeneity/alignment'
+	 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+	 xmlns:xsd='http://www.w3.org/2001/XMLSchema#' 
+	 alignmentSource='AgreementMakerLight'>
+
+<Alignment>
+	<xml>yes</xml>
+	<level>0</level>
+	<type>11</type>
+	<onto1>https://w3id.org/bot#</onto1>
+	<onto2>http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2</onto2>
+	<uri1>https://w3id.org/bot#</uri1>
+	<uri2>http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2</uri2>
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Element"/>
+			<entity2 rdf:resource="http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#IfcBuildingElement"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.7774</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Space"/>
+			<entity2 rdf:resource="http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#IfcSpaceType"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.6083</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+</Alignment>
+</rdf:RDF>

--- a/ResultsAlignmentMaker/BOT2SAREF4BuildingAlignment.rdf
+++ b/ResultsAlignmentMaker/BOT2SAREF4BuildingAlignment.rdf
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF xmlns='http://knowledgeweb.semanticweb.org/heterogeneity/alignment'
+	 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+	 xmlns:xsd='http://www.w3.org/2001/XMLSchema#' 
+	 alignmentSource='AgreementMakerLight'>
+
+<Alignment>
+	<xml>yes</xml>
+	<level>0</level>
+	<type>11</type>
+	<onto1>https://w3id.org/bot#</onto1>
+	<onto2>https://w3id.org/def/saref4bldg</onto2>
+	<uri1>https://w3id.org/bot#</uri1>
+	<uri2>https://w3id.org/def/saref4bldg</uri2>
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Building"/>
+			<entity2 rdf:resource="https://w3id.org/def/saref4bldg#Building"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.99</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+</Alignment>
+</rdf:RDF>

--- a/ResultsAlignmentMaker/BOT2ThinkHomeAlignment.rdf
+++ b/ResultsAlignmentMaker/BOT2ThinkHomeAlignment.rdf
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF xmlns='http://knowledgeweb.semanticweb.org/heterogeneity/alignment'
+	 xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+	 xmlns:xsd='http://www.w3.org/2001/XMLSchema#' 
+	 alignmentSource='AgreementMakerLight'>
+
+<Alignment>
+	<xml>yes</xml>
+	<level>0</level>
+	<type>??</type>
+	<onto1>https://w3id.org/bot#</onto1>
+	<onto2>https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl</onto2>
+	<uri1>https://w3id.org/bot#</uri1>
+	<uri2>https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl</uri2>
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Space"/>
+			<entity2 rdf:resource="https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#Space"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.9801</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Building"/>
+			<entity2 rdf:resource="https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#Building"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.9801</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+	<map>
+		<Cell>
+			<entity1 rdf:resource="https://w3id.org/bot#Building"/>
+			<entity2 rdf:resource="https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntologySharedVocabulary.owl#Building"/>
+			<measure rdf:datatype="http://www.w3.org/2001/XMLSchema#float">0.9801</measure>
+			<relation>=</relation>
+		</Cell>
+	</map>
+
+</Alignment>
+</rdf:RDF>

--- a/SAREF4BLDGAlignment.ttl
+++ b/SAREF4BLDGAlignment.ttl
@@ -1,4 +1,4 @@
-# Copyright 2017 W3C Linked Building Data Community Group.
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
 # 
 # This work is licensed under a Creative Commons Attribution License. 
 # This copyright applies to the BOT Vocabulary Specification and
@@ -44,25 +44,34 @@ foaf:name a owl:DatatypeProperty .
   dcterms:title "SAREF4BLDG Alignment."@en ;
   dcterms:description """This ontology defines proposed alignments of SAREF4BLDG with the BOT ontology."""@en ;
   dcterms:issued "2017-07-13"^^xsd:date ;
-  dce:modified "2017-08-31"^^xsd:date ;
+  dce:modified "2019-03-02"^^xsd:date ;
   dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
   dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+  rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
   dcterms:contributor [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
   dcterms:contributor [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
   dcterms:contributor <http://www.maxime-lefrancois.info/me#> ;
   dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
-  owl:versionInfo "v0.2.0" ;
+  owl:versionInfo "v1.0.0" ;
+  owl:versionIRI <https://w3id.org/bot/SAREF4BLDGAlignment/1.0.0> ;
+  owl:priorVersion <https://w3id.org/bot/SAREF4BLDGAlignment/0.2.0> ;
   owl:imports <https://w3id.org/bot> ;
   owl:imports <https://w3id.org/def/saref4bldg> .
    
 #################################
-# ALIGNMENTS
+# Class alignments
 #################################
 
-saref4bldg:Building         rdfs:subClassOf bot:Building .      
+saref4bldg:Building         rdfs:subClassOf bot:Building .
 saref4bldg:PhysicalObject   rdfs:subClassOf bot:Element .
+saref4bldg:Sensor           rdfs:subClassOf bot:Element .
+saref4bldg:Actuator         rdfs:subClassOf bot:Element .
 saref4bldg:BuildingSpace    rdfs:subClassOf bot:Space .
 
-saref4bldg:hasSpace         rdfs:subPropertyOf bot:hasSpace .
+#################################
+# Object property alignments
+#################################
+
+saref4bldg:hasSpace         rdfs:subPropertyOf bot:containsZone .
 saref4bldg:contains         rdfs:subPropertyOf bot:containsElement .
 

--- a/THINKHOMEAlignment.ttl
+++ b/THINKHOMEAlignment.ttl
@@ -1,3 +1,11 @@
+# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# 
+# This work is licensed under a Creative Commons Attribution License. 
+# This copyright applies to the Vocabulary Specification and
+# accompanying documentation in RDF. Regarding underlying technology,
+# the Vocabulary uses W3C's RDF technology, an open Web standard that can be freely 
+# used by anyone.
+
 @prefix : <https://w3id.org/bot/THINKHOMEAlignment#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -9,6 +17,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix bot: <https://w3id.org/bot#> .
 @prefix th: <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#> .
+@prefix thsv: <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntologySharedVocabulary.owl#> .
 @base <https://w3id.org/bot/THINKHOMEAlignment> .
 
 <https://w3id.org/bot/THINKHOMEAlignment> rdf:type owl:Ontology , voaf:Vocabulary ;
@@ -17,10 +26,14 @@
 	dcterms:issued "2017-09-12"^^xsd:date ;
 	dcterms:modified "2017-09-12"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
+    owl:versionInfo "v1.0.0" ;
+    owl:versionIRI <https://w3id.org/bot/THINKHOMEAlignment/1.0.0> ;
+    owl:priorVersion <https://w3id.org/bot/THINKHOMEAlignment/0.1.0> ;
 	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
 	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
-	owl:imports 	<https://w3id.org/bot> ,
-					<https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl> .
+	owl:imports 	<https://w3id.org/bot> , 
+    <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#>.
 
 dcterms:title a owl:AnnotationProperty .
 dcterms:description a owl:AnnotationProperty .
@@ -42,26 +55,32 @@ th:Campus rdfs:subClassOf bot:Site .
 th:Building rdfs:subClassOf bot:Building .
 th:BuildingStorey rdfs:subClassOf bot:Storey .
 
-th:Zone rdfs:subClassOf bot:Space .
+th:Opening rdfs:subClassOf bot:Element .
 th:Space rdfs:subClassOf bot:Space .
 
+th:Zone rdfs:subClassOf bot:Zone .
+
+th:Construction rdfs:subClassOf bot:Interface .
+th:Layer rdfs:subClassOf bot:Interface .
+th:Material rdfs:subClassOf bot:Interface .
 th:SpaceBoundary rdfs:subClassOf bot:Interface .
 th:Surface rdfs:subClassOf bot:Interface .
 
 th:Equipment rdfs:subClassOf bot:Element .
-th:Construction rdfs:subClassOf bot:Element .
-th:Layer rdfs:subClassOf bot:Element .
-th:Material rdfs:subClassOf bot:Element .
-th:Opening rdfs:subClassOf bot:Element .
 
-th:containsBuilding rdfs:subPropertyOf bot:containsZone .
-th:containsBuildingStorey rdfs:subPropertyOf bot:containsZone .
-th:containsLocation rdfs:subPropertyOf bot:containsZone .
+#################################################################
+#    Object properties
+#################################################################
 
-th:containsOpening rdfs:subPropertyOf bot:hosts .
-
+th:containsBuilding rdfs:subPropertyOf bot:hasBuilding .
+th:containsBuildingStorey rdfs:subPropertyOf bot:hasStorey .
 th:containsSpace rdfs:subPropertyOf bot:hasSpace .
+th:containsSpaceBoundary rdfs:subPropertyOf bot:interfaceOf .
+th:containsLighting rdfs:subPropertyOf bot:containsElement .
+th:containsHydronicLoopEquipment rdfs:subPropertyOf bot:hasSubElement .
+th:containsAirLoopEquipment rdfs:subPropertyOf bot:hasSubElement .
 
-th:hasDefinedAdjacentSpace rdfs:subPropertyOf bot:adjacentZone .
 
+th:hasDefinedAdjacentSpace rdfs:subPropertyOf [ owl:inverseOf bot:adjacentZone ] .
 th:isDefinedAdjacentSurfaceOf rdfs:subPropertyOf bot:interfaceOf .
+thsv:isEquipmentOf rdfs:subPropertyOf [ owl:inverseOf bot:hasElement ] .


### PR DESCRIPTION
Dear all!

I will not be able to stay long at the git issue sprint.

Regarding merging the alignments in the GH repo please consider the ones in the "AlignmentRevision" ones as the latest. I compared and checked differences to the "revisingAlignments" branch, which is deprecated.

In general, the alignments need to be revised also by other experts and members of the group. In particular see the comments by @MadsHolten and @mpoveda in the pull request https://github.com/w3c-lbd-cg/bot/pull/22.

The problems identified are

* bot:containsElement and bot:containsZone less generic then s4bldg:contains?  
* bot:Building less generic then s4bldg:PhysicalSpace?  


subclasses of saref4bldg:contains rather than the other way around since these are more specific?

