### PR TITLE
Revision of BOT to version v0.3.1

### DIFF
--- a/bot-0.3.0.ttl
+++ b/bot-0.3.0.ttl
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 W3C Linked Building Data Community Group.
+# Copyright 2017-2018 W3C Linked Building Data Community Group.
 # 
 # This work is licensed under a Creative Commons Attribution License. 
 # This copyright applies to the BOT Vocabulary Specification and
@@ -8,7 +8,7 @@
 
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:      <http://www.w3.org/2002/07/owl#> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix  rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms:  <http://purl.org/dc/terms/> .
 @prefix vann:     <http://purl.org/vocab/vann/> .
@@ -37,11 +37,11 @@ foaf:name a owl:DatatypeProperty .
 
 
 <https://w3id.org/bot#> rdf:type owl:Ontology , voaf:Vocabulary ;
-    dcterms:modified    "2019-07-23"^^xsd:date ;
+    dcterms:modified    "2018-06-21"^^xsd:date ;
     dcterms:issued    "2018-06-21"^^xsd:date ;
-    owl:versionInfo    "0.3.1" ;
-    owl:versionIRI <https://w3id.org/bot/0.3.1> ;
-    owl:priorVersion <https://w3id.org/bot/0.3.0> ;
+    owl:versionInfo    "0.3.0" ;
+    owl:versionIRI <https://w3id.org/bot/0.3.0> ;
+    owl:priorVersion <https://w3id.org/bot/0.2.0> ;
   rdfs:seeAlso <https://doi.org/10.24928/JC3-2017/0153> , <https://www.researchgate.net/publication/320631574_Recent_changes_in_the_Building_Topology_Ontology> ;
     dcterms:title    "The Building Topology Ontology (BOT)"@en ;
     dcterms:description    """The Building Topology Ontology (BOT) is a simple ontology defining the core concepts of a building.
@@ -55,25 +55,20 @@ The version 0.2.0 of the ontology is documented in:
 
 Mads Holten Rasmussen, Pieter Pauwels, Maxime Lefrançois, Georg Ferdinand Schneider, Christian Anker Hviid and Jan Karlshøj (2017) Recent changes in the Building Topology Ontology, 5th Linked Data in Architecture and Construction Workshop (LDAC2017), November 13-15, 2017, Dijon, France, https://www.researchgate.net/publication/320631574_Recent_changes_in_the_Building_Topology_Ontology
 
-The initial version 0.1.0 of the ontology was documented in:
+The initial version of the ontology was documented in:
 
 Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (2017) Proposing a Central AEC Ontology That Allows for Domain Specific Extensions, Lean and Computing in Construction Congress (LC3): Volume I – Proceedings of the Joint Conference on Computing in Construction (JC3), July 4-7, 2017, Heraklion, Greece, pp. 237-244 https://doi.org/10.24928/JC3-2017/0153"""@en ;
-    dcterms:creator "Mads Holten Rasmussen" ;
-    dcterms:creator "Pieter Pauwels" ;
-	dcterms:contributor "All contributing members of the W3C Linked Building Data Community Group" ;
-	dcterms:contributor "Maxime Lefrançois" ;
-	dcterms:contributor "Georg Ferdinand Schneider" ;
+    dcterms:creator [a foaf:Person ; foaf:name    "Mads Holten Rasmussen" ] ;
+    dcterms:creator [a foaf:Person ; foaf:name    "Pieter Pauwels" ] ;
+    dcterms:contributor [a foaf:Person ; foaf:name    "Georg Ferdinand Schneider" ] ;
     dcterms:contributor <http://maxime-lefrancois.info/me#> ;
-	dcterms:contributor <https://orcid.org/0000-0002-2033-859X> ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix    "bot" ;
     vann:preferredNamespaceUri <https://w3id.org/bot#> .
     
 <http://maxime-lefrancois.info/me#> a foaf:Person ; 
   foaf:name    "Maxime Lefrançois" .
-  
-<https://orcid.org/0000-0002-2033-859X> a foaf:Person ; 
-  foaf:name    "Georg Ferdinand Schneider" .
+
 
 
 ## Zones
@@ -86,11 +81,9 @@ bot:Zone a owl:Class ;
     "Zone"@nl ,
     "Zone"@da ,
     "Zon"@sv ,
-	"Zone"@de ,
     "Zone"@fr ;
   rdfs:comment
     "A spatial 3D division. Sub-classes of bot:Zones include bot:Site, bot:Building, bot:Storey, or bot:Space. An instance of bot:Zone can contain other bot:Zone instances, making it possible to group or subdivide zones. An instance of bot:Zone can be adjacent to other bot:Zone instances. Finally, a bot:Zone can instantiate two relations to bot:Element, which are either contained in (bot:containsElement), or adjacent to it (bot:adjacentElement)."@en ,
-	"Ein abstraktes Konzept für eine räumliche, dreidimensionale Einteilung eines Raums. Spezialisierungen von bot:Zone sind bot:Site, bot:Building, bot:Storey oder bot:Space. Eine Instanz von bot:Zone kannn andere Instanzen von bot:Zone enthalten. So ist es möglich Instanzen von bot:Zone zu gruppieren, oder zu unterteilen. Eine Instanz einer bot:Zone kann an eine andere Instanz von bot:Zone angrenzen. Es bestehen zwei Möglichkeiten Instanzen von bot:Zone und bot:Element in Beziehung zu setzen. Entweder ein Element ist in einer Zone enthalten (bot:containsElement) oder es grenzt an eine andere Zone an (bot:adjacentElement)."@de ,
     "Una área o espacio de tierra que tiene una característica, propósito o uso particular, o que está sujeto a restricciones particulares. Un bot:Zone puede contener otros bot:Zones definidos mediante la relación bot:containsZone, y puede estar conectado con otros bot:Zones mediante la relación bot:adjacentZone."@es ,
     "En rummelig 3D-inddeling. Underklasser af bot:Zone inkluderer bot:Site, bot:Building, bot:Storey eller bot:Space. En bot:Zone forekomst kan indeholde andre bot:Zone forekomster, hvilket gør det muligt at gruppere eller underinddele zoner. En forekomst af bot:Zone kan være tilstødende til andre bot:Zone forekomster. Endelig kan en bot:Zone instantiere to relationer til et bot:Element, hvilke er enten indeholdt i (bot:containsElement) eller tilstødende dertil (bot:adjacentElement)."@da ,
     "En area eller ett stycke land som har en specifik karaktäristik, syfte, användning eller är förmål för specifika restriktioner. En bot:Zone kan innehålla andra bot:Zoner genom relationen bot:containsZone, och den kan kopplas till andra bot:Zoner genom relationen bot:adjacentZone."@sv ,
@@ -99,7 +92,6 @@ bot:Zone a owl:Class ;
   owl:disjointWith
     bot:Element ,
     bot:Interface ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
   bot:Site a owl:Class ;
@@ -124,7 +116,6 @@ bot:Zone a owl:Class ;
       bot:Building ,
       bot:Storey ,
       bot:Space ;
-    vs:term_status "stable" ;
     rdfs:isDefinedBy bot: .
 
 
@@ -151,8 +142,7 @@ bot:Zone a owl:Class ;
       bot:Site ,
       bot:Storey ,
       bot:Space ;
-    vs:term_status "stable" ;
-	rdfs:isDefinedBy bot: .
+    rdfs:isDefinedBy bot: .
 
   bot:Storey a owl:Class ;
     rdfs:label
@@ -178,8 +168,7 @@ bot:Zone a owl:Class ;
       bot:Site ,
       bot:Building ,
       bot:Space ;
-    vs:term_status "stable" ;
-	rdfs:isDefinedBy bot: .
+    rdfs:isDefinedBy bot: .
 
   bot:Space a owl:Class ;
     rdfs:label
@@ -204,8 +193,7 @@ bot:Zone a owl:Class ;
         bot:Site ,
         bot:Building ,
         bot:Storey ;
-      vs:term_status "stable" ;
-	  rdfs:isDefinedBy bot: .
+      rdfs:isDefinedBy bot: .
 
 
 bot:adjacentZone a owl:ObjectProperty , owl:SymmetricProperty ;
@@ -215,14 +203,12 @@ bot:adjacentZone a owl:ObjectProperty , owl:SymmetricProperty ;
     "aangrenzende zone"@nl ,
     "tilstødende zone"@da ,
     "angränsande zon"@sv ,
-	"angrenzende Zone"@de ,
     "zone adjacente"@fr ;
   rdfs:comment
     "Relationship between two zones that share a common interface, but do not intersect."@en ,
-    "Relatie tussen twee zones die een interface delen"@nl ,
-    "Relation mellem to zoner, der deler en fælles grænseflade."@da ,
-    "Relation mellan två zoner som delar ett gemensamt gränssnitt."@sv ,
-	"Beziehung zwischen zwei Zonen die eine gemeinsame Grenzfläche haben, aber sich nicht schneiden."@de ,
+    "TODO: Relatie tussen twee zones die een interface delen"@nl ,
+    "TODO: Relation mellem to zoner, der deler en fælles grænseflade."@da ,
+    "TODO: Relation mellan två zoner som delar ett gemensamt gränssnitt."@sv ,
     "Relation entre deux zones partageant une interface commune, sans intersection"@fr ;
   rdfs:domain bot:Zone ;
   rdfs:range bot:Zone ;
@@ -237,18 +223,25 @@ bot:adjacentZone a owl:ObjectProperty , owl:SymmetricProperty ;
     bot:Storey ,
     bot:Space ;
   owl:propertyDisjointWith
+#    bot:containsZone, # not allowed in OWL 2 DL
     bot:intersectsZone ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
 
 bot:intersectsZone a owl:ObjectProperty , owl:SymmetricProperty ;
   rdfs:label
     "intersects zone"@en ,
-    "sich schneidende Zone"@de ;
+    "TODO"@es ,
+    "TODO"@nl ,
+    "TODO"@da ,
+    "TODO"@sv ,
+    "TODO"@fr ;
   rdfs:comment
     "Relationship between two zones whose 3D extent intersect. For example, a stairwell intersects different storeys."@en ,
-    "Beziehung zwischen zwei Zonen, die sich schneiden. Zum Beispiel schneidet eine Treppe verschiedene Geschosse."@de ;
+    "TODO"@nl ,
+    "TODO"@da ,
+    "TODO"@sv ,
+    "TODO"@fr ;
   rdfs:domain bot:Zone ;
   rdfs:range bot:Zone ;
   schema:domainIncludes
@@ -262,8 +255,8 @@ bot:intersectsZone a owl:ObjectProperty , owl:SymmetricProperty ;
     bot:Storey ,
     bot:Space ;
   owl:propertyDisjointWith
+#    bot:containsZone , # not allowed in OWL 2 DL
     bot:adjacentZone ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
 
@@ -274,11 +267,9 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
     "bevat zone"@nl ,
     "indeholder zone"@da ,
     "innehåller zon"@sv ,
-	"enthält Zone"@de ,
     "contient zone"@fr ;
   rdfs:comment
-    "Relationship to the subzones of a major zone. A space zone could for instance be contained in a storey zone which is further contained in a building zone. bot:containsZone is a transitive property. This implies that in the previous example a bot:containsZone relationship holds between the space zone and the building zone."@en ,
-	"Beziehung zwischen Zonen, wobei eine die andere enthält. Zum Beispiel kann eine Raumzone in einer Geschossszone enthalten sein, die wiederrum in einer Gebäudezone enthalten ist. bot:containsZone is eine transitive Beziehung, dass heisst zwischen der Raumzone im vorherigen Beispiel und der Gebäudezone besteht auch die Beziehung bot:containsZone."@de ,
+    "Relationship to the subzones of a major zone. A space zone could for instance be contained in a storey zone which is further contained in a building zone. bot:containsZone is a transitive property meaning that in the previous example the space zone would also be contained in the building zone."@en ,
     "Relation til underzoner i en større zone. En rum-zone kan for eksempel være indeholdt i en etage-zone som ydermere er indeholdt i en bygnings-zone. bot:containsZone er en transitiv egenskab, hvilket betyder at rum-zonen i det forrige eksempel også er indeholdt i bygnings-zonen."@da ,
     "Relation till delzoner i en huvudzon. En rumszon kan till exempel inrymmas i en våningszon som i sin tur inryms i en byggnadszon. bot:containsZone är en transitiv relation vilket i exemplet betyder att rumszonen också inryms i byggnadszonen."@sv ,
     "Relatie tussen subzones van een hoofd zone. Een ruimtezone kan bijvoorbeeld worden bevat door een verdiepingszone, die wederom bevat wordt door een gebouwzone. bot:containsZone is een transitieve eigenschap, wat betekent dat in het vorige voorbeeld de ruimtezone ook bevat wordt door de gebouwzone."@nl ,
@@ -295,7 +286,9 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
     bot:Building ,
     bot:Storey ,
     bot:Space ;
-  vs:term_status "stable" ;
+#  owl:propertyDisjointWith # not allowed in OWL 2 DL
+#    bot:adjacentZone,
+#    bot:intersectsZone ;
   rdfs:isDefinedBy bot: .
 
   bot:hasBuilding a owl:ObjectProperty ;
@@ -305,11 +298,9 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
       "heeft gebouw"@nl ,
       "har bygning"@da ,
       "har byggnad"@sv ,
-	  "hat Gebäude"@de ,
       "contient bâtiment"@fr ;
     rdfs:comment
       "Relation to buildings contained in a zone. The typical domains of bot:hasBuilding are instances of bot:Site."@en ,
-	  "Beziehung zwischen Gebäuden, die in einer Zone enthalten sind. Oft ist hier die rdfs:domain eine Instanz von bot:Site."@de ,
       "Relatie tot gebouwen die zich op een terrein bevinden"@nl ,
       "Relation til bygninger indeholdt i en zone. De typiske domæner for bot:hasBuilding er forekomster af bot:Site."@da ,
       "Relation till byggnader som inryms i en zon. Typiska domäner för bot:hasBuilding är förekomster av bot:Site."@sv ,
@@ -318,36 +309,34 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
     rdfs:domain bot:Zone ;
     schema:domainIncludes bot:Site ;
     rdfs:range bot:Building ;
-    vs:term_status "stable" ;
-	rdfs:isDefinedBy bot: .
+    rdfs:isDefinedBy bot: .
 
   bot:hasStorey a owl:ObjectProperty ;
     rdfs:label
       "has storey"@en ,
       "tiene piso"@es ,
       "heeft verdieping"@nl ,
+      "hat geschoss"@de ,
       "har etage"@da ,
       "har våning"@sv ,
-	  "hat Geschoss"@de ,
       "a étage"@fr ;
     rdfs:comment
       "Relation to storeys contained in a zone. The typical domains of bot:hasStorey are instances of bot:Building."@en ,
-	  "Beziehung zwischen Geschossen, die in einer Zone enthalten sind. Oft ist die rdfs:domain eine Instanz von bot:Building."@de ,
       "Relatie tot de verdiepingen die zich in een zone bevinden. De typische domeinen van bot:hasStorey zijn instanties van bot:Building"@nl ,
+        #"Beziehung zu in Gebäude enthaltenden Geschossen"@de ,
       "Relation til etager indeholdt i en zone. De typiske domæner for bot:hasStorey er forekomster af bot:Building."@da ,
       "Relation à définir entre les étages d'une même zone. Cette propriété s'applique typiquement sur des instances de bot:Building."@fr ;
     rdfs:subPropertyOf bot:containsZone ;
     rdfs:domain bot:Zone ;
     schema:domainIncludes bot:Building ;
     rdfs:range bot:Storey ;
-	vs:term_status "stable" ;
     rdfs:isDefinedBy bot: .
     
   bot:hasSpace a owl:ObjectProperty ;
     rdfs:label
       "has space"@en ,
       "tiene espacio"@es ,
-      "hat Raum"@de ,
+      "hat raum"@de ,
       "heeft ruimte"@nl ,
       "har rum"@da ,
       "har rum"@sv ,
@@ -356,7 +345,7 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
       "Relation to spaces contained in a zone. The typical domains of bot:hasSpace are instances of bot:Storey and bot:Building."@en ,
       "Relación a espacios contenidos en una zona. Los dominios típicos de bot:hasSPace son instancias de bot:Storey y bot:Building."@es ,
       "Relatie tot ruimtes die zich in een zone bevinden. De typische domeinen van bot:hasSpace zijn instanties van bot:Storey en bot:Building."@nl ,
-      "Beziehung von Räumen, die sich in einer Zone befinden. Oft ist die rdfs:domain eine Instanz von bot:Storey oder bot:Building."@de ,
+        #"Beziehung zu Räumen, die sich in einem Geschoss befinden"@de ,
       "Relation til rum indeholdt i en zone. De typiske domæner for bot:hasSpace er forekomster af bot:Storey og bot:Building."@da ,
       "Relation till rum som inryms i en zon. Typiska domäner för bot:hasSpace är förekomster av bot:Storey och bot:Building."@sv ,
       "Relation à définir entre les pièces d'une même zone. Cette propriété s'applique typiquement sur des instances de bot:Building."@fr ;
@@ -364,7 +353,6 @@ bot:containsZone a owl:ObjectProperty , owl:TransitiveProperty ;
     rdfs:domain bot:Zone ;
     schema:domainIncludes bot:Storey ;
     rdfs:range bot:Space ;
-	vs:term_status "stable" ;
     rdfs:isDefinedBy bot: .
     
 
@@ -391,7 +379,6 @@ bot:Element a owl:Class ;
     "Bestanddeel van een gebouwde entiteit met een karakteristieke technische functie, vorm of positie [12006-2, 3.4.7]"@nl ,
     "Constituant d'un bâtiment remplissant une fonction technique spécifique ou ayant une forme ou une position spécifiques"@fr ;
   owl:disjointWith bot:Zone , bot:Interface ; 
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
     
 bot:hasSubElement a owl:ObjectProperty ;
@@ -402,18 +389,15 @@ bot:hasSubElement a owl:ObjectProperty ;
     "hoster sub element"@da ,
     "värd för sub element"@sv ,
     "heeft sub element"@nl ,
-	"hat Unterbauteil"@de ,
     "a sous-élément"@fr ;        
   rdfs:comment
     "Relation between an element a) and another element b) hosted by element a)"@en ,
     "Relatie tussen een gebouwelement a) en een ander element b) dat een ander element in zich heeft a). Voorbeeld: inst:wall bot:hasSubElement inst:window"@nl ,
-	"Beziehung zwischen einem Bauteil und a) einem anderen Bauteil oder b) einem Bauteil, dass ein anderes Bauteil enthält."@de ,
     "Relation mellem en bygningsdel a) og en anden bygningsdel b) hostet af element a). Eksempel: inst:wall bot:hasSubElement inst:window"@da ,
     "Relation mellan en byggdel a) och en annan byggdel b) som utgör värd a). Exempel: inst:wall bot:hasSubElement inst:window"@sv ,
     "Relation entre un élément du bâti A et un autre élément du bâti, B, contenu ou abrité dans A"@fr ;
   rdfs:domain bot:Element ;
   rdfs:range bot:Element ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
  
@@ -425,16 +409,16 @@ bot:hasElement a owl:ObjectProperty ;
     "har element"@da ,
     "värd för element"@sv ,
     "heeft element"@nl ,
-	"hat Bauteil"@de ,
     "a élément"@fr ;        
   rdfs:comment
     "Links a Zone to an Element that is either contained in or adjacent to, the Zone. The intended use of this relationship is not to be stated explicitly, but to be inferred from its sub-properties. It will, for example, allow one to query for all the doors of a building given that they have an adjacency to spaces of the building."@en ,
-    "Forbinder en Zone til en bygningsdel der enten er indeholdt i eller tilstødende til zonen. Det er ikke hensigten at denne relation angives eksplicit, men at den udledes af dennes underegneskaber. Det vil for eksempel tillade en forespørgsel på alle døre i en bygning givet at disse er enten tilstødende eller indeholdt i rum i bygningen."@da ,
-    "Beziehung zwischen einer Zone und einem Bauteil, dass entweder in der Zone enthalten ist, oder sich mit ihr schneidet. Diese Beziehung sollte nicht explizit benutzt werden, sondern ergibt sich implizit aus den Unterbeziehungen. Es ermöglicht, zum Beispiel, dass mit einer Abfrage alle Türen eines Gebäudes, die sich mit einer Zone schneiden ermittelt werden können."@de ;
+    " TODO "@nl ,
+    " Forbinder en Zone til en bygningsdel der enten er indeholdt i eller tilstødende til zonen. Det er ikke hensigten at denne relation angives eksplicit, men at den udledes af dennes underegneskaber. Det vil for eksempel tillade en forespørgsel på alle døre i en bygning givet at disse er enten tilstødende eller indeholdt i rum i bygningen."@da ,
+    " TODO "@sv ,
+    " TODO "@fr ;
   rdfs:domain bot:Zone ;
   rdfs:range bot:Element ;
   owl:propertyChainAxiom ( bot:containsZone bot:hasElement ) ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
   bot:adjacentElement a owl:ObjectProperty ;
@@ -442,22 +426,22 @@ bot:hasElement a owl:ObjectProperty ;
       "adjacent element"@en ,
       "elemento adyacente"@es ,
       "aangrenzend element"@nl ,
-      "benachbartes Bauteil"@de ,
+      "benachbartes bauteil"@de ,
       "tilstødende element"@da ,
       "angränsande element"@sv ,
       "élément adjacent"@fr ;
     rdfs:comment
       "Relation between a zone and its adjacent building elements, bounding the zone."@en ,
       "Relación entre una zona y sus elementos arquitectónicos adyacentes, que limitan el espacio físico."@es ,
-      "Beziehung zwischen einer Zone und dessen angrenzenden Bauteilen. Die Bauteile begrenzen die Zone."@de ,
+      #"Beziehung eines Raumes zu Bauteilen die in begrenzen"@de ,
       "Relatie tussen een zone en zijn aangrenzende gebouwelementen, begrensd door fysieke ruimte."@nl ,
       "Relation mellem en zone og dens tilstødende bygningsdele, som afgrænser det fysiske rum."@da ,
       "Relation mellan en zon och dess angränsande byggdelar, som avgränsar det fysiska utrymmet."@sv ,
       "Relation entre une zone et ses éléments adjacents, délimitant l'espace physique"@fr ;
     rdfs:subPropertyOf bot:hasElement ;
     owl:propertyDisjointWith
+#      bot:containsElement, # not allowed in OWL 2 DL
       bot:intersectingElement ;
-	vs:term_status "stable" ;
     rdfs:isDefinedBy bot: .
     
   bot:containsElement a owl:ObjectProperty ;
@@ -465,36 +449,46 @@ bot:hasElement a owl:ObjectProperty ;
       "contains element"@en ,
       "contiene elemento"@es ,
       "bevat element"@nl ,
-      "enthält Bauteil"@de ,
+      "enthält"@de ,
       "indeholder bygningsdel"@da ,
       "innehåller byggdel"@sv ,
       "contient élément"@fr ;        
     rdfs:comment
       "Relation to a building element contained in a zone."@en ,
       "Relación a un elemento arquitectónico contenido en una zona."@es ,
-      "Beziehung einer Zone zu einem Bauteil, dass es enthält."@de ,
+      #"Beziehung eines Raums zu einem Bauteil"@de ,
       "Relatie tussen zone en een gebouwelement in die zone"@nl ,
       "Relation til en bygningsdel, som er indeholdt i en zone."@da ,
       "Relation till en byggdel som inryms i en zon."@sv ,
       "Relation à définir entre un élément de bâti et la zone le contenant"@fr ;
     rdfs:subPropertyOf bot:hasElement ;
     owl:propertyChainAxiom  ( bot:containsZone bot:containsElement ) ;
-    vs:term_status "stable" ;
-	rdfs:isDefinedBy bot: .
+#    owl:propertyDisjointWith # not allowed in OWL 2 DL
+#      bot:adjacentElement,
+#      bot:intersectingElement ;
+    rdfs:isDefinedBy bot: .
 
   bot:intersectingElement a owl:ObjectProperty ;
     rdfs:label
       "intersecting element"@en ,
-      "schneidendes Bauteil"@de ,
+      "TODO"@es ,
+      "TODO"@nl ,
+      "TODO"@de ,
+      "TODO"@da ,
+      "TODO"@sv ,
       "élément intersectant"@fr ;
     rdfs:comment
       "Relation between a Zone and a building Element that intersects it. "@en ,
-      "Beziehung zwischen einer Zone und einem Bauteil, das die Zone schneidet."@de ;
+      "TODO"@es ,
+      "TODO"@nl ,
+      "TODO"@da ,
+      "TODO"@sv ,
+      "TODO"@fr ;
     rdfs:subPropertyOf bot:hasElement ;
     owl:propertyDisjointWith
+#      bot:containsElement, # not allowed in OWL 2 DL
       bot:adjacentElement ;
-    vs:term_status "stable" ;
-	rdfs:isDefinedBy bot: .
+    rdfs:isDefinedBy bot: .
 
 
 ## Interfaces
@@ -504,39 +498,38 @@ bot:Interface a owl:Class ;
   rdfs:label
     "Interface"@en ,
     "Interface"@nl ,
-	"Grenzfläche"@de ,
     "Grænseflade"@da ,
     "Gränssnitt"@sv ,
     "Interface"@fr ;        
   rdfs:comment
     "An interface is the surface where two building elements, two zones or a building element and a zone meet. It can be used for qualification of the connection between the two. A use case could be qualification of the heat transmission area between a zone and a wall covering several zones."@en ,
-	"Eine Grenzfläche ist die Fläche, an der sich zwei Bauteile, zwei Zonen oder ein Bauteil und eine Zone treffen. Das Konzept kann verwendet werden, um die Beziehung zwischen den Beteiligten zu qualifizieren. Ein Beispiel ist die Qualifizierung der Wärmeaustauschfläche zwischen eine Zone und einer Wand, die mehrere Zonen überdeckt."@de ,
     "Een interface is een vlak waar twee gebouwelementen, twee zones of een gebouw elementen en een zone elkaar raken. Het kan worden gebruikt om de verbinding tussen de twee te kwalificeren. Een use case kan de kwalificatie van het warmteoverbrengingsoppervlak tussen een zone en een muur over meerdere zones zijn."@nl ,
     "En grænseflade er fladen hvor to bygningsdele, to zoner eller en bygningsdel og en zone mødes. Den kan benyttes til at kvalificere forbindelsen mellem de to. En use case kunne være kvalifikation af varmetransmissionsarealet mellem en zone og en væg som dækker flere zoner."@da ,
     "Ett gränssnitt är den yta där två byggdelar, två zoner eller en b yggdel och en zon möts. Det kan användas för att beskriva kopplingen mellan de två. Ett användningsfall kan vara att kvalificera värmetransmissionsarean mellan en zon och en vägg som täcker flera zoner."@sv ,
     "Une interface correspond à la surface où se rencontrent a) deux éléments d'un bâtiment, b) deux zones ou  encore c) un élément d'un bâtiment avec une zone. Un cas d'utilisation type est constituée par la qualification de la zone de transmission de chaleur entre une zone et un mur couvrant plusieurs zones."@fr ;
   owl:disjointWith bot:Zone, bot:Element ;
-  vs:term_status "stable" ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bot:interfaceOf ;
+    owl:minCardinality 1
+  ] ;
   rdfs:isDefinedBy bot: .
 
 
 bot:interfaceOf a owl:ObjectProperty ;
   rdfs:label
     "interface of"@en ,
-	"Grenzfläche von"@de ,
     "interface van"@nl ,
     "grænseflade for"@da ,
     "gränssnitt för"@sv ,
     "interface de"@fr ;
   rdfs:comment
     "Relationship between an interface and an adjacent zone or element."@en ,
-	"Beziehung zwischen einer Grenzfläche und einer angrenzenden Zone oder einem Bauteil."@de ,
     "Relatie tussen een interface en een aanliggende zone of element."@nl ,
     "Relation mellem en grænseflade og en tilstødende zone eller bygningsdel."@da ,
     "Relation mellan ett gränssnitt och en angränsande zon eller byggdel."@sv ,
     "Relation à définir entre une interface et une zone ou un élément adjacents."@fr ;
   rdfs:domain bot:Interface ;
-  vs:term_status "stable" ;
   rdfs:isDefinedBy bot: .
 
 
@@ -544,45 +537,30 @@ bot:interfaceOf a owl:ObjectProperty ;
 ## 3DModel
 
 bot:hasZeroPoint a owl:ObjectProperty ;
-  rdfs:label
-    "has zero point"@en ,
-	"hat Nullpunkt"@de ,
-    "har nulpunkt"@da ;
-  rdfs:comment
-    "Links a bot:Site to a wgs84:Point that encodes the latitude and longitude of the Zero Point of the building site."@en ,
-    "Verbindet eine Instanz von bot:Site mit einem wgs84:Point, der den Längen- und Breitengrad des Nullpunkts des Grundstücks definiert."@de ,
-	"Forbinder et bot:Site med et wgs84:Point som beskriver længde- og breddegrad for projektets nulpunkt"@da ;
-  rdfs:domain   bot:Site ;
-  vs:term_status "unstable" ;
+  rdfs:label    "has zero point"@en ,
+                "har nulpunkt"@da ;
+  rdfs:comment  "Links a bot:Site to a wgs84:Point that encodes the latitude and longitude of the Zero Point of the building site."@en ,
+                "Forbinder et bot:Site med et wgs84:Point som beskriver længde- og breddegrad for projektets nulpunkt"@da ;
+  rdfs:domain   bot:Site ;  
   rdfs:isDefinedBy bot: .
 
 bot:hasSimple3DModel a owl:DatatypeProperty ;
-  rdfs:label
-    "has Simple 3D Model"@en ,
-	"hat einfaches 3D Modell"@de ,
-	"har simpel 3D-model"@da ;
-  rdfs:comment
-    "Links any bot:Zone or bot:Element to a 3D Model encoded as a literal."@en ,
-    "Verbindet jede bot:Zone oder bot:Element zu einem 3D Model, dass als Literal codiert ist."@de ,
-	"Forbinder enhver instans af bot:Zone eller bot:Element med en 3D-model beskrevet som en literal."@da ;
+  rdfs:label    "has Simple 3D Model"@en ,
+                "har simpel 3D-model"@da ;
+  rdfs:comment  "Links any bot:Zone or bot:Element to a 3D Model encoded as a literal."@en ,
+                "Forbinder enhver instans af bot:Zone eller bot:Element med en 3D-model beskrevet som en literal."@da ;
   schema:domainIncludes
     bot:Element,
     bot:Zone ;
-  vs:term_status "unstable" ;
   rdfs:isDefinedBy bot: .
 
 bot:has3DModel a owl:ObjectProperty ;
-  rdfs:label
-    "has 3D Model"@en ,
-    "hat 3D Modell"@de ,
-	"har 3D-model"@da ;
-  rdfs:comment
-    "Links any bot:Zone or bot:Element to a IRI that identifies its 3D Model. This 3D Model can then be described using some dedicated RDF vocabulary. Else, the 3D Model IRI could be dereferenceable, and when looking up the IRI one could retrieve a representation of the 3D Model with some existing data format for 3D models."@en ,
-    "Verbindet eine Instanz von bot:Zone oder bot:Element zu einer IRI, die das zugehörige 3D Modell identifiziert. Das Modell kann in einem spezifischen RDF Vokabular kodiert sein. Andernfalls kann die IRI auch dereferenzierbar sein."@de ,
-	"Forbinder enhver instans af bot:Zone eller bot:Element med en IRI som identificerer dennes 3D-model. Denne 3D-model kan så beskrives ved brug af et dedikeret RDF-vokabular. Alternativt kan 3D-modellens IRI være dereferencerbar, sådan at der modtages en repræsentation af 3D-modellen i et eksisterende dataformat for 3D-modeller når IRIen slås op."@da ;
+  rdfs:label    "has 3D Model"@en ,
+                "har 3D-model"@da ;
+  rdfs:comment  "Links any bot:Zone or bot:Element to a IRI that identifies its 3D Model. This 3D Model can then be described using some dedicated RDF vocabulary. Else, the 3D Model IRI could be dereferenceable, and when looking up the IRI one could retrieve a representation of the 3D Model with some existing data format for 3D models."@en ,
+                "Forbinder enhver instans af bot:Zone eller bot:Element med en IRI som identificerer dennes 3D-model. Denne 3D-model kan så beskrives ved brug af et dedikeret RDF-vokabular. Alternativt kan 3D-modellens IRI være dereferencerbar, sådan at der modtages en repræsentation af 3D-modellen i et eksisterende dataformat for 3D-modeller når IRIen slås op."@da ;
   schema:domainIncludes
     bot:Element,
     bot:Zone ;
-  vs:term_status "unstable" ;
   rdfs:isDefinedBy bot: .
 

--- a/index.html
+++ b/index.html
@@ -1416,22 +1416,37 @@ h:heatedBy a owl:ObjectProperty ;
         </section>
     </section>
     <section class="appendix" id="acknowledgments">
-        <h2>Acknowledgments</h2> The Editors recognize the major contribution of the members of the W3C Linked Building Data Community Group.</section>
+        <h2>Acknowledgments</h2> The editors recognize the major contribution of the members of the W3C Linked Building Data Community Group.</section>
     <section class="appendix" id="changes">
         <h2>Change History</h2>
         <p><em>List not complete</em></p>
-        <h2>Changes decided during LDAC2018</h2>
+		
+		<h3>Revisions of BOT to version v0.3.1</h3>
+        <p>These changes are documented via a <a href="https://github.com/w3c-lbd-cg/bot/pull/49">Pull Request (PR)</a> in the groups Github repository.</p>
+        <p>Changes applied based on <a href="http://www.semantic-web-journal.net/comment/321#comment-321">comments</a> receives by Antoine Zimmermann</p>
+		<ol>
+            <li> Removal of cardinality restriction on <a href="#Interface"><code>bot:Interface</code></a> to ensure BOT stays in OWL RL.</li>
+            <li>Removal of TODO language tags</li>
+			<li>Removal of commented axioms</li>
+        </ol>
+		<p>In addition the following changes are applied:</p>
+        <ol>
+            <li>Revision of labels and comments in German language</li>
+            <li>Addition of W3C Linked Building Data Community Group members as contributors</li>
+        </ol>
+		
+		<h3>Changes decided during LDAC2018</h3>
         <ol>
             <li>Added <a href="#intersectingElement">bot:intersectingElement</a> and <a href="#intersectsZone">bot:intersectsZone</a> following resolution reported in <a href="https://github.com/w3c-lbd-cg/bot/issues/30">GitHub issue #30</a></li>
             <li>Added <a href="#hasZeroPoint">bot:hasZeroPoint</a>, <a href="#has3DModel">bot:has3DModel</a>, <a href="#hasSimple3DModel">bot:hasSimple3DModel</a> following resolution reported in <a href="https://github.com/w3c-lbd-cg/bot/issues/37">GitHub issue #37</a></li>
         </ol>
-        <h2>Changes since <a href="https://doi.org/10.13140/RG.2.2.32365.28647">Recent changes in the Building Topology Ontology</a> presented at LDAC2017</h2>
+        <h3>Changes since <a href="https://doi.org/10.13140/RG.2.2.32365.28647">Recent changes in the Building Topology Ontology</a> presented at LDAC2017</h3>
         <ol>
             <li>Renamed <a href="#hostsElement">bot:hostsElement</a> to <a href="#hasSubElement">bot:hasSubElement</a>.</li>
             <li>Define <a href="#hasElement">hasElement</a> as super property of <a href="#adjacentElement">bot:adjacentElement</a> and <a href="#containsElement">bot:containsElement</a></li>
         </ol>
-        <h2>Changes since Original <a href="http://www.student.dtu.dk/~mhoras/bot/index-en.html">
-            (http://www.student.dtu.dk/~mhoras/bot/index-en.html)</a> presented at LC3</h2>
+        <h3>Changes since Original <a href="http://www.student.dtu.dk/~mhoras/bot/index-en.html">
+            (http://www.student.dtu.dk/~mhoras/bot/index-en.html)</a> presented at LC3</h3>
         <p>These changes are documented in <a href="https://doi.org/10.13140/RG.2.2.32365.28647">Recent changes in the Building Topology Ontology</a></p>
         <ol>
             <li><a href="#Site"><code>bot:Site</code></a> added.</li>


### PR DESCRIPTION
Based on comments received from Antoine Zimmermann [LINK](http://www.semantic-web-journal.net/comment/321#comment-321):

- Removal of cardinality restriction on bot:Interface to ensure BOT stays in OWL RL:
bot:Interface rdfs:subClassOf [
  a owl:Restriction ;
  owl:onProperty bot:interfaceOf ;
  owl:minCardinality 1 ] .
--> Minor loss vs. huge gain staying in the efficient to reason OWL RL profile
-	Removal of “TODO” language tags
-	Removal of commented axioms

In addition the following minor changes have been applied:
-	Revision of @de labels and comments
-	Addition of W3C CG members as contributors