### PR TITLE
removal of foaf:name

### DIFF
--- a/BRICKAlignment.ttl
+++ b/BRICKAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix brick: <https://brickschema.org/schema/1.0.2/Brick#> .
 @base <https://w3id.org/bot/BRICKAlignment> .
@@ -23,14 +24,14 @@
 	dcterms:title "BRICK to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the BRICK ontology."""@en ;
 	dcterms:issued "2017-09-12"^^xsd:date ;
-	dcterms:modified "2019-03-01"^^xsd:date ;
+	dcterms:modified "2020-08-05"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
     owl:versionInfo "v1.0.0" ;
     owl:versionIRI <https://w3id.org/bot/BRICKAlignment/1.0.0> ;
     owl:priorVersion <https://w3id.org/bot/BRICKAlignment/0.1.0> ;
-	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
-    rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator "Georg Ferdinand Schneider" ;
+	rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<https://brickschema.org/schema/1.0.2/Brick#> .
 
@@ -43,8 +44,12 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
 											   
 #################################################################

--- a/DERIROOMAlignment.ttl
+++ b/DERIROOMAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix rooms: <http://vocab.deri.ie/rooms#> .
 @base <https://w3id.org/bot/DERIROOMAlignment> .
@@ -29,8 +30,8 @@
     owl:versionIRI <https://w3id.org/bot/DERIROOMAlignment/1.0.0> ;
     owl:priorVersion <https://w3id.org/bot/DERIROOMAlignment/0.1.0> ;
     rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
-	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator "Georg Ferdinand Schneider" ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://vocab.deri.ie/rooms#> .
 
@@ -43,8 +44,12 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
 #################################################################
 #    Alignments

--- a/DOGONTAlignment.ttl
+++ b/DOGONTAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix dogont: <http://elite.polito.it/ontologies/dogont.owl#> .
 @base <https://w3id.org/bot/DOGONTAlignment> .
@@ -28,9 +29,9 @@
     owl:versionInfo "v1.0.0" ;
     owl:versionIRI <https://w3id.org/bot/DOGONTAlignment/1.0.0> ;
     owl:priorVersion <https://w3id.org/bot/DOGONTAlignment/0.1.0> ;
-	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator "Georg Ferdinand Schneider" ;
     rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://elite.polito.it/ontologies/dogont.owl> .
 
@@ -43,9 +44,13 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
+	
 #################################################################
 #    Object properties
 #################################################################

--- a/DULAlignment.ttl
+++ b/DULAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
 @base <https://w3id.org/bot/DULAlignment> .
@@ -28,10 +29,10 @@
     owl:versionInfo "v0.1.0" ;
     owl:versionIRI <https://w3id.org/bot/DULAlignment/0.1.0> ;
 	dcterms:creator <http://maxime-lefrancois.info/me#> ;
-	dcterms:contributor <https://www.researchgate.net/profile/Georg_Schneider3> ;
     rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:contributor [ a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
-	dcterms:creator [ a foaf:Person ; foaf:name "Maxime Lefrançois" ] ;
+	dcterms:contributor <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:contributor "Georg Ferdinand Schneider" ;
+	dcterms:creator "Maxime Lefrançois" ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://www.ontologydesignpatterns.org/ont/dul/DUL.owl> .
 
@@ -44,8 +45,16 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
 #################################################################
 #    Classes

--- a/IFCOWL4_ADD2Alignment.ttl
+++ b/IFCOWL4_ADD2Alignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix ifc: <http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2#> .
 @base <https://w3id.org/bot/IFCOWL4_ADD2Alignment> .
@@ -28,9 +29,9 @@
     owl:versionInfo "v1.0.0" ;
     owl:versionIRI <https://w3id.org/bot/IFCOWL4_ADD2Alignment/1.0.0> ;
     owl:priorVersion <https://w3id.org/bot/IFCOWL4_ADD2Alignment/0.1.0> ;
-	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
     rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:creator [ a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator "Georg Ferdinand Schneider" ;
 	owl:imports 	<https://w3id.org/bot> ,
 					<http://www.buildingsmart-tech.org/ifcOWL/IFC4_ADD2> .
 
@@ -43,8 +44,12 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
 #################################################################
 #    Classes

--- a/RECAlignment.ttl
+++ b/RECAlignment.ttl
@@ -14,8 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
-@prefix schema:   <http://schema.org/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema:   <https://schema.org/>.
 @prefix bot: <https://w3id.org/bot#> .
 @prefix recCore: <https://w3id.org/rec/core/> .
 @prefix recBuilding: <https://w3id.org/rec/building/> .
@@ -25,20 +25,22 @@
 	dcterms:title "REC to BOT alignment."@en ;
 	dcterms:description """This ontology defines proposed alignments with the RealEstateCore ontology. The alignments are based on BOT version [0.3.0](https://w3id.org/bot/bot-0.3.0.ttl)."""@en ;
 	dcterms:issued "2020-05-19"^^xsd:date ;
-	dcterms:modified "2020-05-19"^^xsd:date ;
+	dcterms:modified "2020-08-05"^^xsd:date ;
 	dcterms:license <http://creativecommons.org/licenses/by/3.0/> ;
     owl:versionInfo "v0.1.0" ;
     owl:versionIRI <https://w3id.org/bot/RECAlignment/0.1.0> ;
     owl:priorVersion <https://w3id.org/bot/RECAlignment/0.1.0> ;
 	dcterms:creator <https://orcid.org/0000-0002-6519-7057> , <https://orcid.org/0000-0001-8767-4136> ;
+	dcterms:creator "Karl Hammar" , "Mads Holten Rasmussen" ;
 	owl:imports <https://w3id.org/bot> ,
 					<https://w3id.org/rec/full/3.1.3/> .
           
-<https://orcid.org/0000-0002-6519-7057> a foaf:Person , schema:Person ; 
-  foaf:name    "Mads Holten Rasmussen" ;
-  schema:name    "Mads Holten Rasmussen" .
-<https://orcid.org/0000-0001-8767-4136> a foaf:Person , schema:Person ; 
-  foaf:name    "Karl Hammar" ;
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+	
+<https://orcid.org/0000-0001-8767-4136> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Karl Hammar" ;
   schema:name    "Karl Hammar" .
 
 dcterms:title a owl:AnnotationProperty .
@@ -50,9 +52,7 @@ dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
-schema:Person a owl:Class .
+vcard:fn a owl:AnnotationProperty .
 schema:name a owl:DatatypeProperty .
 
 											   

--- a/SAREF4BLDGAlignment.ttl
+++ b/SAREF4BLDGAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix vann:   	<http://purl.org/vocab/vann/> .
 @prefix voaf:   	<http://purl.org/vocommons/voaf#> .
 @prefix vs:     	<http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix foaf:   	<http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix dce:    	<http://purl.org/dc/elements/1.1/> .
 @prefix dbo:    	<http://dbpedia.org/ontology/> .
 @prefix saref4bldg:	<https://w3id.org/def/saref4bldg#> .
@@ -22,6 +23,27 @@
 @prefix : <https://w3id.org/bot/> .
 @prefix bot: <https://w3id.org/bot#> .
 @base <https://w3id.org/bot/SAREF4BLDGAlignment#> .
+
+:SAREFG4BLDGAlignment a owl:Ontology , voaf:Vocabulary ;
+  dcterms:title "SAREF4BLDG Alignment."@en ;
+  dcterms:description """This ontology defines proposed alignments of SAREF4BLDG with the BOT ontology."""@en ;
+  dcterms:issued "2017-07-13"^^xsd:date ;
+  dce:modified "2019-03-02"^^xsd:date ;
+  dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+  dcterms:creator "Georg Ferdinand Schneider" ;
+  dcterms:contributor "Mads Holten Rasmussen" ;
+  dcterms:contributor "Pieter Pauwels" ;
+  dcterms:contributor "Maxime Lefrançois" ;
+  dcterms:contributor <http://maxime-lefrancois.info/me#> ;
+  dcterms:contributor <https://orcid.org/0000-0002-6519-7057> ;
+  dcterms:contributor <https://orcid.org/0000-0001-8020-4609> ;
+  rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
+  dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
+  owl:versionInfo "v1.0.0" ;
+  owl:versionIRI <https://w3id.org/bot/SAREF4BLDGAlignment/1.0.0> ;
+  owl:priorVersion <https://w3id.org/bot/SAREF4BLDGAlignment/0.2.0> ;
+  owl:imports <https://w3id.org/bot> ;
+  owl:imports <https://w3id.org/def/saref4bldg> .
 
 voaf:Vocabulary a owl:Class .
 dcterms:title a owl:AnnotationProperty .
@@ -34,30 +56,28 @@ dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
 vs:term_status a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
 
-#################################
-# METADATA
-#################################
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+ 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
-:SAREFG4BLDGAlignment a owl:Ontology , voaf:Vocabulary ;
-  dcterms:title "SAREF4BLDG Alignment."@en ;
-  dcterms:description """This ontology defines proposed alignments of SAREF4BLDG with the BOT ontology."""@en ;
-  dcterms:issued "2017-07-13"^^xsd:date ;
-  dce:modified "2019-03-02"^^xsd:date ;
-  dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
-  dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
-  rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-  dcterms:contributor [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
-  dcterms:contributor [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
-  dcterms:contributor <http://www.maxime-lefrancois.info/me#> ;
-  dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
-  owl:versionInfo "v1.0.0" ;
-  owl:versionIRI <https://w3id.org/bot/SAREF4BLDGAlignment/1.0.0> ;
-  owl:priorVersion <https://w3id.org/bot/SAREF4BLDGAlignment/0.2.0> ;
-  owl:imports <https://w3id.org/bot> ;
-  owl:imports <https://w3id.org/def/saref4bldg> .
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
+
+
+   
+   
    
 #################################
 # Class alignments

--- a/THINKHOMEAlignment.ttl
+++ b/THINKHOMEAlignment.ttl
@@ -14,7 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .  
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 @prefix bot: <https://w3id.org/bot#> .
 @prefix th: <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#> .
 @prefix thsv: <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntologySharedVocabulary.owl#> .
@@ -29,9 +30,9 @@
     owl:versionInfo "v1.0.0" ;
     owl:versionIRI <https://w3id.org/bot/THINKHOMEAlignment/1.0.0> ;
     owl:priorVersion <https://w3id.org/bot/THINKHOMEAlignment/0.1.0> ;
-	dcterms:creator <https://www.researchgate.net/profile/Georg_Schneider3> ;
     rdfs:seeAlso <https://doi.org/10.13140/RG.2.2.21802.52169> ;
-	dcterms:creator [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator "Georg Ferdinand Schneider" ;
 	owl:imports 	<https://w3id.org/bot> , 
     <https://www.auto.tuwien.ac.at/downloads/thinkhome/ontology/BuildingOntology.owl#>.
 
@@ -40,12 +41,15 @@ dcterms:description a owl:AnnotationProperty .
 dcterms:issued a owl:AnnotationProperty .
 dcterms:modified a owl:AnnotationProperty .
 dcterms:creator a owl:AnnotationProperty .
-dcterms:contributor a owl:AnnotationProperty .
 dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
 #################################################################
 #    Classes

--- a/bot-0.1.0.ttl
+++ b/bot-0.1.0.ttl
@@ -17,6 +17,8 @@
 @prefix foaf:   <http://xmlns.com/foaf/0.1/> .
 @prefix dce:    <http://purl.org/dc/elements/1.1/> .
 @prefix dbo:    <http://dbpedia.org/ontology/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 
 @prefix bot: <https://w3id.org/bot#> .
 @base <https://w3id.org/bot#> .
@@ -32,8 +34,9 @@ dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
 vs:term_status a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
+
 
 #################################
 # METADATA
@@ -49,9 +52,12 @@ It is a simple, easy to extend ontology for the construction industry to documen
 The ontology is documented in:
 
 Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (2017) Proposing a Central AEC Ontology That Allows for Domain Specific Extensions, Lean and Computing in Construction Congress (LC3): Volume I – Proceedings of the Joint Conference on Computing in Construction (JC3), July 4-7, 2017, Heraklion, Greece, pp. 237-244 http://itc.scix.net/cgi-bin/works/Show?lc3-2017-153"""@en ;
-    dcterms:creator [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
-    dcterms:creator [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
-    dcterms:contributor [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
+    dcterms:creator "Mads Holten Rasmussen" ;
+    dcterms:creator "Pieter Pauwels" ;
+	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator <https://orcid.org/0000-0002-6519-7057> ;
+	dcterms:contributor "Georg Ferdinand Schneider" ;
+	dcterms:contributor <https://orcid.org/0000-0001-8020-4609> ;
     dcterms:issued "2016-05-25"^^xsd:date ;
 	dcterms:modified "2017-07-11"^^xsd:date ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
@@ -59,6 +65,18 @@ Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (
     vann:preferredNamespaceUri <https://w3id.org/bot#> ;
     dce:Language "en" ;
     dce:description "A simple ontology describing the topology of a building" .
+
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+ vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
+
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
     
 #################################
 # CLASSES

--- a/bot-0.2.0.ttl
+++ b/bot-0.2.0.ttl
@@ -17,6 +17,8 @@
 @prefix foaf:   	<http://xmlns.com/foaf/0.1/> .
 @prefix dce:    	<http://purl.org/dc/elements/1.1/> .
 @prefix dbo:    	<http://dbpedia.org/ontology/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 
 @prefix bot: <https://w3id.org/bot#> .
 @base <https://w3id.org/bot#> .
@@ -32,8 +34,8 @@ dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
 vs:term_status a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
 
 #################################
 # METADATA
@@ -57,16 +59,36 @@ Mads Holten Rasmussen, Pieter Pauwels, Maxime Lefrançois, Georg Ferdinand Schne
 The initial version of the ontology was documented in:
 
 Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (2017) Proposing a Central AEC Ontology That Allows for Domain Specific Extensions, Lean and Computing in Construction Congress (LC3): Volume I – Proceedings of the Joint Conference on Computing in Construction (JC3), July 4-7, 2017, Heraklion, Greece, pp. 237-244 https://doi.org/10.24928/JC3-2017/0153"""@en ;
-    dcterms:creator [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
-    dcterms:creator [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
-    dcterms:contributor [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
-    dcterms:contributor [a foaf:Person ; foaf:name "Maxime Lefrançois" ] ;
+	dcterms:creator "Mads Holten Rasmussen" ;
+	dcterms:creator "Pieter Pauwels" ;
+	dcterms:contributor "Maxime Lefrançois" ;
+	dcterms:contributor "Georg Ferdinand Schneider" ;
+	dcterms:contributor <http://maxime-lefrancois.info/me#> ;
+	dcterms:contributor <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator <https://orcid.org/0000-0002-6519-7057> ;
+	dcterms:creator <https://orcid.org/0000-0001-8020-4609> ;	
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix "bot" ;
     vann:preferredNamespaceUri <https://w3id.org/bot#> ;
     dce:Language "en" ;
     dce:title "BOT" ;
     dce:description "A simple ontology describing the topology of a building" .
+
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+ 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
+
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
     
 #################################
 # CLASSES

--- a/bot-0.3.0.ttl
+++ b/bot-0.3.0.ttl
@@ -8,7 +8,7 @@
 
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:      <http://www.w3.org/2002/07/owl#> .
-@prefix  rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms:  <http://purl.org/dc/terms/> .
 @prefix vann:     <http://purl.org/vocab/vann/> .
@@ -17,7 +17,8 @@
 @prefix foaf:     <http://xmlns.com/foaf/0.1/> .
 @prefix dce:      <http://purl.org/dc/elements/1.1/> .
 @prefix dbo:      <http://dbpedia.org/ontology/> .
-@prefix schema:   <http://schema.org/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 
 @prefix bot: <https://w3id.org/bot#> .
 
@@ -32,8 +33,8 @@ dcterms:license a owl:AnnotationProperty .
 vann:preferredNamespacePrefix a owl:AnnotationProperty .
 vann:preferredNamespaceUri a owl:AnnotationProperty .
 vs:term_status a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
 
 
 <https://w3id.org/bot#> rdf:type owl:Ontology , voaf:Vocabulary ;
@@ -58,18 +59,34 @@ Mads Holten Rasmussen, Pieter Pauwels, Maxime Lefrançois, Georg Ferdinand Schne
 The initial version of the ontology was documented in:
 
 Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (2017) Proposing a Central AEC Ontology That Allows for Domain Specific Extensions, Lean and Computing in Construction Congress (LC3): Volume I – Proceedings of the Joint Conference on Computing in Construction (JC3), July 4-7, 2017, Heraklion, Greece, pp. 237-244 https://doi.org/10.24928/JC3-2017/0153"""@en ;
-    dcterms:creator [a foaf:Person ; foaf:name    "Mads Holten Rasmussen" ] ;
-    dcterms:creator [a foaf:Person ; foaf:name    "Pieter Pauwels" ] ;
-    dcterms:contributor [a foaf:Person ; foaf:name    "Georg Ferdinand Schneider" ] ;
-    dcterms:contributor <http://maxime-lefrancois.info/me#> ;
+    dcterms:creator "Mads Holten Rasmussen" ;
+	dcterms:creator "Pieter Pauwels" ;
+	dcterms:contributor "Maxime Lefrançois" ;
+	dcterms:contributor "Georg Ferdinand Schneider" ;
+	dcterms:contributor <http://maxime-lefrancois.info/me#> ;
+	dcterms:contributor <https://orcid.org/0000-0002-2033-859X> ;
+	dcterms:creator <https://orcid.org/0000-0002-6519-7057> ;
+	dcterms:creator <https://orcid.org/0000-0001-8020-4609> ;	
+	dcterms:contributor "All contributing members of the W3C Linked Building Data Community Group" ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix    "bot" ;
     vann:preferredNamespaceUri <https://w3id.org/bot#> .
     
-<http://maxime-lefrancois.info/me#> a foaf:Person ; 
-  foaf:name    "Maxime Lefrançois" .
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+ 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
 
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
 
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
 
 ## Zones
 

--- a/bot-0.3.1.ttl
+++ b/bot-0.3.1.ttl
@@ -17,7 +17,8 @@
 @prefix foaf:     <http://xmlns.com/foaf/0.1/> .
 @prefix dce:      <http://purl.org/dc/elements/1.1/> .
 @prefix dbo:      <http://dbpedia.org/ontology/> .
-@prefix schema:   <http://schema.org/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 
 @prefix bot: <https://w3id.org/bot#> .
 
@@ -62,20 +63,32 @@ The initial version 0.1.0 of the ontology was documented in:
 Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (2017) Proposing a Central AEC Ontology That Allows for Domain Specific Extensions, Lean and Computing in Construction Congress (LC3): Volume I – Proceedings of the Joint Conference on Computing in Construction (JC3), July 4-7, 2017, Heraklion, Greece, pp. 237-244 https://doi.org/10.24928/JC3-2017/0153"""@en ;
   dcterms:creator "Mads Holten Rasmussen" ;
   dcterms:creator "Pieter Pauwels" ;
-	dcterms:creator "Maxime Lefrançois" ;
-	dcterms:creator "Georg Ferdinand Schneider" ;
+  dcterms:creator "Maxime Lefrançois" ;
+  dcterms:creator "Georg Ferdinand Schneider" ;
   dcterms:creator <http://maxime-lefrancois.info/me#> ;
-	dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+  dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
+  dcterms:creator <https://orcid.org/0000-0002-6519-7057> ;
+  dcterms:creator <https://orcid.org/0000-0001-8020-4609> ;
   dcterms:contributor "All contributing members of the W3C Linked Building Data Community Group" ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix    "bot" ;
     vann:preferredNamespaceUri <https://w3id.org/bot#> .
     
-<http://maxime-lefrancois.info/me#> a foaf:Person ; 
-  foaf:name    "Maxime Lefrançois" .
-  
-<https://orcid.org/0000-0002-2033-859X> a foaf:Person ; 
-  foaf:name    "Georg Ferdinand Schneider" .
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+ 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
+
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
 
 
 ## Zones

--- a/bot.ttl
+++ b/bot.ttl
@@ -14,10 +14,10 @@
 @prefix vann:     <http://purl.org/vocab/vann/> .
 @prefix voaf:     <http://purl.org/vocommons/voaf#> .
 @prefix vs:       <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix foaf:     <http://xmlns.com/foaf/0.1/> .
 @prefix dce:      <http://purl.org/dc/elements/1.1/> .
 @prefix dbo:      <http://dbpedia.org/ontology/> .
-@prefix schema:   <http://schema.org/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix schema: <https://schema.org/> .
 
 @prefix bot: <https://w3id.org/bot#> .
 
@@ -34,8 +34,8 @@ vann:preferredNamespaceUri a owl:AnnotationProperty .
 schema:domainIncludes a owl:AnnotationProperty .
 schema:rangeIncludes a owl:AnnotationProperty .
 vs:term_status a owl:AnnotationProperty .
-foaf:Person a owl:Class .
-foaf:name a owl:DatatypeProperty .
+vcard:fn a owl:AnnotationProperty .
+schema:name a owl:AnnotationProperty .
 
 
 <https://w3id.org/bot#> rdf:type owl:Ontology , voaf:Vocabulary ;
@@ -44,7 +44,7 @@ foaf:name a owl:DatatypeProperty .
     owl:versionInfo    "0.3.2" ;
     owl:versionIRI <https://w3id.org/bot/0.3.2> ;
     owl:priorVersion <https://w3id.org/bot/0.3.1> ;
-  rdfs:seeAlso <https://doi.org/10.24928/JC3-2017/0153> , <https://www.researchgate.net/publication/320631574_Recent_changes_in_the_Building_Topology_Ontology> ;
+  rdfs:seeAlso <https://doi.org/10.24928/JC3-2017/0153> , <https://www.researchgate.net/publication/320631574_Recent_changes_in_the_Building_Topology_Ontology> , <http://www.semantic-web-journal.net/system/files/swj2279.pdf> ;
     dcterms:title    "The Building Topology Ontology (BOT)"@en ;
     dcterms:description    """The Building Topology Ontology (BOT) is a simple ontology defining the core concepts of a building.
 It is a simple, easy to extend ontology for the construction industry to document and exchange building data on the web.
@@ -61,20 +61,28 @@ Mads Holten Rasmussen, Pieter Pauwels, Christian Anker Hviid and Jan Karlshøj (
   dcterms:creator <http://maxime-lefrancois.info/me#> ;
   dcterms:creator <https://orcid.org/0000-0002-2033-859X> ;
   dcterms:creator <https://orcid.org/0000-0002-6519-7057> ;
+  dcterms:creator <https://orcid.org/0000-0001-8020-4609> ;
   dcterms:contributor "All contributing members of the W3C Linked Building Data Community Group" ;
   dcterms:contributor "Mathias Bonduel" , "Sjoerd Rongen" , "Katja Breitenfelder" , "Edison Chung" , "María Poveda-Villalón" , "Ville Kukkonen" , "Lars Wikström" , "Karl Hammar" , "Hervé Pruvost" , "Ana Roxin" , "Gonçal Costa", "Walter Terkaj", "Rui de Klerk", "Rui Ma", "Richard Pinka", "Jyrki Oraskari" , "Edison Chung", "Ali Kücükavci" , "Sjoerd Rongen" , "Pouya Zangeneh" ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix    "bot" ;
     vann:preferredNamespaceUri <https://w3id.org/bot#> .
-    
-<http://maxime-lefrancois.info/me#> a foaf:Person ; 
-  foaf:name    "Maxime Lefrançois" .
-  
-<https://orcid.org/0000-0002-2033-859X> a foaf:Person ; 
-  foaf:name    "Georg Ferdinand Schneider" .
 
-<https://orcid.org/0000-0002-6519-7057> a foaf:Person ; 
-  foaf:name    "Mads Holten Rasmussen" .
+<http://maxime-lefrancois.info/me#> a vcard:Individual , schema:Person; 
+	vcard:fn   "Maxime Lefrançois" ;
+	schema:name "Maxime Lefrançois" .
+ 
+<https://orcid.org/0000-0002-2033-859X> a vcard:Individual , schema:Person; 
+	vcard:fn    "Georg Ferdinand Schneider" ;
+	schema:name "Georg Ferdinand Schneider" .
+
+<https://orcid.org/0000-0002-6519-7057> a vcard:Individual , schema:Person ; 
+  vcard:fn    "Mads Holten Rasmussen" ;
+	schema:name "Mads Holten Rasmussen" .
+
+<https://orcid.org/0000-0001-8020-4609> a vcard:Individual , schema:Person ; 
+	vcard:fn    "Pieter Pauwels" ;
+	schema:name "Pieter Pauwels" .
 
 ## Zones
 


### PR DESCRIPTION
remove foaf:Person and foaf:name

substituted with vcard and schema.org annotation

removed bnode fashion of stating contributors and creators

closes #11 